### PR TITLE
Make OpenAPIError an instance of Error

### DIFF
--- a/src/__tests__/error.test.js
+++ b/src/__tests__/error.test.js
@@ -2,6 +2,11 @@ import buildError, { OpenAPIError } from '../error';
 
 
 describe('buildError', () => {
+
+    it('is an error', () => {
+        expect(new OpenAPIError('message') instanceof Error).toBe(true);
+    });
+
     it('returns response data', () => {
         try {
             buildError()({

--- a/src/error.js
+++ b/src/error.js
@@ -10,6 +10,7 @@ export function OpenAPIError(message = null, code = 500, data = null) {
     this.code = code;
     this.data = data;
 }
+OpenAPIError.prototype = new Error();
 
 
 /* Extract the most useful fields from an error.


### PR DESCRIPTION
Some libraries expect errors to be `instanceof Error`

Example: https://github.com/graphql/graphql-js/blob/master/src/execution/execute.js#L782