### PR TITLE
Update builder functions to have more correct behavior

### DIFF
--- a/src/__tests__/request.builders.test.js
+++ b/src/__tests__/request.builders.test.js
@@ -15,7 +15,9 @@ describe('buildData', () => {
         const req = null;
         expect(
             buildData(context, req, {
-                foo: 'bar',
+                body: {
+                    foo: 'bar',
+                },
             }),
         ).toEqual({
             foo: 'bar',
@@ -73,14 +75,34 @@ describe('buildParams', () => {
         );
     });
 
-    it('returns verbatim for get', () => {
+    it('returns underscore for get', () => {
         const context = {
             method: 'get',
         };
         const req = null;
         expect(
-            buildParams(context, req, {}),
+            buildParams(context, req, {
+                fooBar: 'bar',
+            }),
         ).toEqual({
+            foo_bar: 'bar',
+        });
+    });
+
+    it('returns joined arrays for get', () => {
+        const context = {
+            method: 'get',
+        };
+        const req = null;
+        expect(
+            buildParams(context, req, {
+                foo: [
+                    'bar',
+                    'baz',
+                ],
+            }),
+        ).toEqual({
+            foo: 'bar,baz',
         });
     });
 });

--- a/src/__tests__/request.test.js
+++ b/src/__tests__/request.test.js
@@ -12,7 +12,9 @@ describe('buildRequest', () => {
         const req = null;
         expect(
             buildRequest(context, req, {
-                foo: 'bar',
+                body: {
+                    foo: 'bar',
+                },
             }),
         ).toEqual({
             adapter: null,
@@ -41,7 +43,9 @@ describe('buildRequest', () => {
         const req = null;
         expect(
             buildRequest(context, req, {
-                foo: 'bar',
+                body: {
+                    foo: 'bar',
+                },
             }),
         ).toEqual({
             adapter: null,

--- a/src/request.js
+++ b/src/request.js
@@ -4,6 +4,7 @@ import {
     capitalize,
     get,
     lowerCase,
+    mapKeys,
     mapValues,
 } from 'lodash';
 
@@ -16,10 +17,7 @@ export function buildData(context, req, args) {
     if (lowerCase(context.method) === 'get') {
         return null;
     }
-    // NB: we ought to require a `body` argument here (within `args`) instead of sending
-    // args verbatim; however too many of our mocks break at the moment if we do so
-    // (because the mocks are too naive)
-    return args;
+    return get(args, 'body');
 }
 
 
@@ -45,8 +43,12 @@ export function buildParams(context, req, args) {
     if (lowerCase(context.method) !== 'get') {
         return null;
     }
-    // NB we should use our naming support here; breaks too many mocks to do so yet
-    return args;
+    const options = get(context, 'options', {});
+    return mapValues(
+        mapKeys(args || {}, (value, key) => nameFor(key, 'query', true, options)),
+        // NB: join arrays into comma-separated lists
+        value => (Array.isArray(value) ? value.join(',') : value),
+    );
 }
 
 


### PR DESCRIPTION
These are behaviors we rely on elsewhere but omitted initially due to issues with
badly written mocks. We've improved our mocking story and can make these behaviors
official:

 -  Pass `POST`/`PUT`/`PATCH` `body` arguments as a parameter named `body`.

    This allows intermingling query parameters and body arguments clearly. It comes at
    the low, low cost of prohibiting a query parameter named `body`. I'm ok with this.

 -  Convert query parameters to `snake_case`

 -  Convert arrays of query parameters to comma-separated values.

    This is a convention we use for $REASONS, but isn't really the HTTP way. I'm ok with
    this too.