### PR TITLE
Improve spec validation and naming

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -11,23 +11,36 @@ import CallableOperation from './operation';
 /* Generate a mapping from (dotted) operation names to callable operations.
  *
  * `spec`: An OpenAPI JSON specificiation. Assuumed to be valid.
- * `serviceName`: A human-friendly name for this API.
+ * `name`: A human-friendly name for this API.
  * `options`: A dictionary of options.
  */
-export default function createClient(spec, serviceName, options = {}) {
+export default function createClient(spec, name, options = {}) {
     const operations = {};
 
-    // for each path
     const { paths } = spec;
+    if (!paths) {
+        throw new Error(`OpenAPI spec for ${name} must define paths`);
+    }
+
+    // for each path
     Object.keys(paths).forEach((path) => {
-        // for each method
         const methods = paths[path];
+
+        // for each method
         Object.keys(methods).forEach((method) => {
 
             // for each tag
             const operation = paths[path][method];
+            if (!operation.tags || !operation.tags.length) {
+                throw new Error(`OpenAPI spec for ${name} must define at least one tag for ${method} ${path}`);
+            }
+
             operation.tags.forEach((tag) => {
                 const { operationId } = operation;
+                if (!operationId) {
+                    throw new Error(`OpenAPI operation for ${name} must define an operationId for ${method} ${path}`);
+                }
+
                 const operationName = operationNameFor(tag, operationId);
                 const context = {
                     spec,
@@ -40,7 +53,7 @@ export default function createClient(spec, serviceName, options = {}) {
                 set(
                     operations,
                     operationName,
-                    CallableOperation(context, serviceName, operationName),
+                    CallableOperation(context, name, operationName),
                 );
             });
         });

--- a/src/operation.js
+++ b/src/operation.js
@@ -11,16 +11,16 @@ import Validator from './validation';
 
 /* Create a new callable operation that return a Promise.
  */
-export default (context, serviceName, operationName) => async (req, args, options) => {
+export default (context, name, operationName) => async (req, args, options) => {
     // validate inputs
     Validator(context)(req, operationName, args);
 
     // allow overiding the http implementation
-    const http = get(context, 'options.http', () => axios)(req, serviceName, operationName);
+    const http = get(context, 'options.http', () => axios)(req, name, operationName);
 
     // enhance the context with service and operation name
     const requestContext = assign({}, context, {
-        serviceName,
+        name,
         operationName,
     });
 


### PR DESCRIPTION
 - Validate required inputs
 - Normalize on `name` instead of `serviceName`