### PR TITLE
Fix validation for missing required arguments

### DIFF
--- a/src/__tests__/validation.test.js
+++ b/src/__tests__/validation.test.js
@@ -32,4 +32,14 @@ describe('validation', () => {
             'Required argument: "chatroomId" not passed to: "chatroom.retrieve"',
         );
     });
+
+    it('enforces that required parameters are non-null', () => {
+        const method = 'get';
+        const path = '/chatroom/{chatroom_id}';
+        const validate = Validator({ spec, method, path });
+
+        expect(() => validate(req, 'chatroom.retrieve', { chatroomId: null })).toThrow(
+            'Required argument: "chatroomId" not passed to: "chatroom.retrieve"',
+        );
+    });
 });

--- a/src/__tests__/validation.test.js
+++ b/src/__tests__/validation.test.js
@@ -42,4 +42,12 @@ describe('validation', () => {
             'Required argument: "chatroomId" not passed to: "chatroom.retrieve"',
         );
     });
+
+    it('enforces that required falsey parameters pass', () => {
+        const method = 'get';
+        const path = '/chatroom/{chatroom_id}';
+        const validate = Validator({ spec, method, path });
+
+        expect(validate(req, 'chatroom.retrieve', { chatroomId: 0 })).toBe(true);
+    });
 });

--- a/src/validation.js
+++ b/src/validation.js
@@ -1,6 +1,6 @@
 /* Validate request arguments.
  */
-import { get, omit } from 'lodash';
+import { get, isNil, omit } from 'lodash';
 
 import { OpenAPIError } from './error';
 import nameFor from './naming';
@@ -37,7 +37,7 @@ function validateQueryAndPathParameters(operation, operationName, args, options)
 
     // there should be no missing required arguments
     Object.keys(parameters).forEach((name) => {
-        if (parameters[name] && !(queryAndPathArgs[name])) {
+        if (parameters[name] && isNil(queryAndPathArgs[name])) {
             const message = `Required argument: "${name}" not passed to: "${operationName}"`;
             throw new OpenAPIError(message);
         }

--- a/src/validation.js
+++ b/src/validation.js
@@ -37,7 +37,7 @@ function validateQueryAndPathParameters(operation, operationName, args, options)
 
     // there should be no missing required arguments
     Object.keys(parameters).forEach((name) => {
-        if (parameters[name] && !(name in queryAndPathArgs)) {
+        if (parameters[name] && !(queryAndPathArgs[name])) {
             const message = `Required argument: "${name}" not passed to: "${operationName}"`;
             throw new OpenAPIError(message);
         }


### PR DESCRIPTION
During retrieve operations, we commonly pass in an args list, causing
this validation to erroneously succeed. We should be failing validation
if a required key was missing, or was supplied with a null value.