### PR TITLE
Include params for delete requests

### DIFF
--- a/src/__tests__/request.builders.test.js
+++ b/src/__tests__/request.builders.test.js
@@ -66,8 +66,10 @@ describe('buildMethod', () => {
 
 
 describe('buildParams', () => {
-    it('returns null for non-get', () => {
-        const context = {};
+    it('returns null if not get or delete', () => {
+        const context = {
+            method: 'post',
+        };
         expect(
             buildParams(context),
         ).toEqual(

--- a/src/request.js
+++ b/src/request.js
@@ -40,9 +40,6 @@ export function buildMethod(context) {
 /* Build request params.
  */
 export function buildParams(context, req, args) {
-    if (lowerCase(context.method) !== 'get') {
-        return null;
-    }
     const options = get(context, 'options', {});
     return mapValues(
         mapKeys(args || {}, (value, key) => nameFor(key, 'query', true, options)),

--- a/src/request.js
+++ b/src/request.js
@@ -3,6 +3,7 @@
 import {
     capitalize,
     get,
+    includes,
     lowerCase,
     mapKeys,
     mapValues,
@@ -40,6 +41,10 @@ export function buildMethod(context) {
 /* Build request params.
  */
 export function buildParams(context, req, args) {
+    if (!includes(['get', 'delete'], lowerCase(context.method))) {
+        return null;
+    }
+
     const options = get(context, 'options', {});
     return mapValues(
         mapKeys(args || {}, (value, key) => nameFor(key, 'query', true, options)),


### PR DESCRIPTION
* allow `buildParams()` if context method is `get` or `delete`

Why?

It is nice to allow params to be passed for delete.