### PR TITLE
Raise error on receiving non-JSON responses

### DIFF
--- a/src/clients/__tests__/openapi.test.js
+++ b/src/clients/__tests__/openapi.test.js
@@ -116,4 +116,20 @@ describe('createOpenAPIClient', () => {
 
         expect(config.clients.mock.petstore.pet.search).toHaveBeenCalledTimes(0);
     });
+
+    it('raises an error if an invalid response content-type header is returned', async () => {
+        const config = await Nodule.testing().fromObject(
+            mockResponse('petstore', 'pet.search', '', {
+                'content-type': 'text/html',
+            }),
+        ).load();
+
+        const client = createOpenAPIClient('petstore', spec);
+
+        await expect(client.pet.search(req)).rejects.toThrow(
+            'text/html is not a valid response content-type',
+        );
+
+        expect(config.clients.mock.petstore.pet.search).toHaveBeenCalledTimes(1);
+    });
 });

--- a/src/clients/openapi.js
+++ b/src/clients/openapi.js
@@ -66,6 +66,13 @@ export function buildHeaders(context, req) {
     return headers;
 }
 
+function validateResponse(response) {
+    const contentType = get(response, 'headers["content-type"]');
+    if (contentType !== 'application/json') {
+        throw new Error(`${contentType} is not a valid response content-type`);
+    }
+}
+
 export function http(req, serviceName, operationName) {
     return (request) => {
         const metadata = getMetadata();
@@ -84,6 +91,7 @@ export function http(req, serviceName, operationName) {
         return axios(
             request,
         ).then((response) => {
+            validateResponse(response);
             if (logSuccess) {
                 logSuccess(req, request, response, requestLogs, executeStartTime);
             }

--- a/src/clients/openapi.js
+++ b/src/clients/openapi.js
@@ -79,7 +79,10 @@ export function http(req, serviceName, operationName) {
         if (metadata.testing) {
             return axios(
                 request,
-            );
+            ).then((response) => {
+                validateResponse(response);
+                return response;
+            });
         }
         const executeStartTime = process.hrtime();
         const { buildRequestLogs, logSuccess, logFailure } = getContainer('logging');

--- a/src/testing/openapi.js
+++ b/src/testing/openapi.js
@@ -5,11 +5,12 @@ import { OpenAPIError } from '../error';
 
 /* Mock a client (OpenAPI) response.
  */
-export function mockResponse(name, operationId, data) {
+export function mockResponse(name, operationId, data, headers = { 'content-type': 'application/json' }) {
     const obj = {};
 
     set(obj, `clients.mock.${name}.${operationId}`, jest.fn(async req => ({
         data: isFunction(data) ? data(req.params || JSON.parse(req.data || null)) : data,
+        headers,
     })));
 
     return obj;


### PR DESCRIPTION
The OpenAPI client is mainly used for creating and receiving JSON data;
in the case that the server starts returning back non-JSON responses
(e.g. maintenance pages), we shouldn't be treating these as valid
responses.

This is meant to solve GLOB-27019, where we end up actually caching the maintenance pages, causing us to need to forcibly reset the cache.
Ideally, this would have been caught in axios itself, but it would appear that we're sending headers like `'application/json, text/plain, */*',`, even though the latter two don't appear to be explicitly specified anywhere.