### PR TITLE
Release 0.11.0 Raise error on receiving non-JSON responses (#23)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.3
+current_version = 0.10.0
 commit = False
 tag = False
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:8.9.1
+    - image: circleci/node:8.11.3
 
 whitelist: &whitelist
   paths:
@@ -18,9 +18,7 @@ jobs:
       - run:
           name: Authenticate NPM
           command: |
-            touch .npmrc
             echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
-
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "yarn.lock" }}
@@ -39,6 +37,17 @@ jobs:
           root: ~/repo
           <<: *whitelist
 
+  lint:
+    <<: *defaults
+
+    steps:
+      - attach_workspace:
+          at: ~/repo
+
+      - run:
+          name: Lint
+          command: yarn lint
+
   test:
     <<: *defaults
 
@@ -48,7 +57,7 @@ jobs:
 
       - run:
           name: Test
-          command: yarn verify
+          command: yarn test
 
       - persist_to_workspace:
           root: ~/repo
@@ -78,7 +87,7 @@ jobs:
 
       - run:
           name: Publish to NPM
-          command: npm publish --access public
+          command: npm publish
 
 workflows:
   version: 2
@@ -86,11 +95,15 @@ workflows:
   build:
     jobs:
       - checkout
+      - lint:
+          requires:
+            - checkout
       - test:
           requires:
             - checkout
       - build:
           requires:
+            - lint
             - test
 
   release:
@@ -101,6 +114,14 @@ workflows:
               only: /[0-9]+(\.[0-9]+)*/
             branches:
               ignore: /.*/
+      - lint:
+          filters:
+            tags:
+              only: /[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/
+          requires:
+            - checkout
       - test:
           filters:
             tags:

--- a/.globality/build.json
+++ b/.globality/build.json
@@ -1,0 +1,7 @@
+{
+  "type": "node-module",
+  "params": {
+    "name": "nodule-openapi",
+    "open_source": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-openapi",
-    "version": "0.9.3",
+    "version": "0.10.0",
     "description": "Opinionated OpenAPI (Swagger) Client",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-openapi.git",

--- a/src/__tests__/request.builders.test.js
+++ b/src/__tests__/request.builders.test.js
@@ -66,8 +66,10 @@ describe('buildMethod', () => {
 
 
 describe('buildParams', () => {
-    it('returns null for non-get', () => {
-        const context = {};
+    it('returns null if not get or delete', () => {
+        const context = {
+            method: 'post',
+        };
         expect(
             buildParams(context),
         ).toEqual(

--- a/src/clients/__tests__/openapi.test.js
+++ b/src/clients/__tests__/openapi.test.js
@@ -116,4 +116,20 @@ describe('createOpenAPIClient', () => {
 
         expect(config.clients.mock.petstore.pet.search).toHaveBeenCalledTimes(0);
     });
+
+    it('raises an error if an invalid response content-type header is returned', async () => {
+        const config = await Nodule.testing().fromObject(
+            mockResponse('petstore', 'pet.search', '', {
+                'content-type': 'text/html',
+            }),
+        ).load();
+
+        const client = createOpenAPIClient('petstore', spec);
+
+        await expect(client.pet.search(req)).rejects.toThrow(
+            'text/html is not a valid response content-type',
+        );
+
+        expect(config.clients.mock.petstore.pet.search).toHaveBeenCalledTimes(1);
+    });
 });

--- a/src/request.js
+++ b/src/request.js
@@ -3,6 +3,7 @@
 import {
     capitalize,
     get,
+    includes,
     lowerCase,
     mapKeys,
     mapValues,
@@ -40,9 +41,10 @@ export function buildMethod(context) {
 /* Build request params.
  */
 export function buildParams(context, req, args) {
-    if (lowerCase(context.method) !== 'get') {
+    if (!includes(['get', 'delete'], lowerCase(context.method))) {
         return null;
     }
+
     const options = get(context, 'options', {});
     return mapValues(
         mapKeys(args || {}, (value, key) => nameFor(key, 'query', true, options)),

--- a/src/testing/openapi.js
+++ b/src/testing/openapi.js
@@ -5,11 +5,12 @@ import { OpenAPIError } from '../error';
 
 /* Mock a client (OpenAPI) response.
  */
-export function mockResponse(name, operationId, data) {
+export function mockResponse(name, operationId, data, headers = { 'content-type': 'application/json' }) {
     const obj = {};
 
     set(obj, `clients.mock.${name}.${operationId}`, jest.fn(async req => ({
         data: isFunction(data) ? data(req.params || JSON.parse(req.data || null)) : data,
+        headers,
     })));
 
     return obj;


### PR DESCRIPTION
The OpenAPI client is mainly used for creating and receiving JSON data; in
    the case that the server starts returning back non-JSON responses
    (e.g. maintenance pages), we shouldn't be treating these as valid
    responses.