### PR TITLE
Add default timeout for requests

### DIFF
--- a/src/__tests__/request.builders.test.js
+++ b/src/__tests__/request.builders.test.js
@@ -155,7 +155,7 @@ describe('buildTimeout', () => {
         const context = {
             spec,
             options: {
-                timeout: 1000,
+                timeout: "1000",
             },
         };
         expect(

--- a/src/__tests__/request.builders.test.js
+++ b/src/__tests__/request.builders.test.js
@@ -4,6 +4,7 @@ import {
     buildHeaders,
     buildMethod,
     buildParams,
+    buildTimeout,
     buildUrl,
     expandPath,
 } from '../request';
@@ -134,6 +135,33 @@ describe('buildUrl', () => {
             buildUrl(context),
         ).toEqual(
             'https://example.com/api/v2/foo',
+        );
+    });
+});
+
+describe('buildTimeout', () => {
+    it('constructs a timeout', () => {
+        const context = {
+            spec,
+            path: '/foo',
+        };
+        expect(
+            buildTimeout(context),
+        ).toEqual(
+            5000,
+        );
+    });
+    it('accepts an override timeout', () => {
+        const context = {
+            spec,
+            options: {
+                timeout: 1000,
+            },
+        };
+        expect(
+            buildTimeout(context),
+        ).toEqual(
+            1000,
         );
     });
 });

--- a/src/__tests__/request.builders.test.js
+++ b/src/__tests__/request.builders.test.js
@@ -155,7 +155,7 @@ describe('buildTimeout', () => {
         const context = {
             spec,
             options: {
-                timeout: "1000",
+                timeout: '1000',
             },
         };
         expect(

--- a/src/__tests__/request.test.js
+++ b/src/__tests__/request.test.js
@@ -27,8 +27,8 @@ describe('buildRequest', () => {
             maxContentLength: -1,
             method: 'post',
             params: null,
-            url: 'http://localhost/api/v2/chatroom',
             timeout: 5000,
+            url: 'http://localhost/api/v2/chatroom',
         });
     });
 
@@ -59,8 +59,8 @@ describe('buildRequest', () => {
             maxContentLength: -1,
             method: 'post',
             params: null,
-            url: 'http://localhost/api/v2/chatroom',
             timeout: 5000,
+            url: 'http://localhost/api/v2/chatroom',
         });
     });
 });

--- a/src/__tests__/request.test.js
+++ b/src/__tests__/request.test.js
@@ -28,6 +28,7 @@ describe('buildRequest', () => {
             method: 'post',
             params: null,
             url: 'http://localhost/api/v2/chatroom',
+            timeout: 5000,
         });
     });
 
@@ -59,6 +60,7 @@ describe('buildRequest', () => {
             method: 'post',
             params: null,
             url: 'http://localhost/api/v2/chatroom',
+            timeout: 5000,
         });
     });
 });

--- a/src/clients/openapi.js
+++ b/src/clients/openapi.js
@@ -134,7 +134,7 @@ export function http(req, serviceName, operationName) {
 export function createOpenAPIClient(name, spec) {
     const metadata = getMetadata();
     const config = getConfig(`clients.${name}`) || {};
-    const { baseUrl } = config;
+    const { baseUrl, timeout } = config;
 
     if (!baseUrl && !metadata.testing && !metadata.debug) {
         throw new Error(`OpenAPI client ${name} does not have a configured baseUrl`);
@@ -145,6 +145,7 @@ export function createOpenAPIClient(name, spec) {
         buildAdapter,
         buildHeaders,
         http,
+        timeout,
     };
     return OpenAPI(spec, name, options);
 }

--- a/src/operation.js
+++ b/src/operation.js
@@ -15,7 +15,7 @@ export default (context, name, operationName) => async (req, args, options) => {
     // validate inputs
     Validator(context)(req, operationName, args);
 
-    // allow overiding the http implementation
+    // allow overriding the http implementation
     const http = get(context, 'options.http', () => axios)(req, name, operationName);
 
     // enhance the context with service and operation name

--- a/src/request.js
+++ b/src/request.js
@@ -100,7 +100,7 @@ export function buildUrl(context, req, args) {
 }
 
 export function buildTimeout(context) {
-    return get(context, 'options.timeout', 5000);
+    return parseInt(get(context, 'options.timeout', 5000));
 }
 
 

--- a/src/request.js
+++ b/src/request.js
@@ -99,6 +99,10 @@ export function buildUrl(context, req, args) {
     return `${baseUrl}${spec.basePath}${expandedPath}`;
 }
 
+export function buildTimeout(context) {
+    return get(context, 'options.timeout', 5000);
+}
+
 
 /* Build base request (to be overridden by other builders).
  */
@@ -123,6 +127,7 @@ const DEFAULT_BUILDERS = {
     method: buildMethod,
     params: buildParams,
     url: buildUrl,
+    timeout: buildTimeout,
 };
 
 

--- a/src/request.js
+++ b/src/request.js
@@ -100,7 +100,7 @@ export function buildUrl(context, req, args) {
 }
 
 export function buildTimeout(context) {
-    return parseInt(get(context, 'options.timeout', 5000));
+    return parseInt(get(context, 'options.timeout', 5000), 10);
 }
 
 


### PR DESCRIPTION
By default axios will never time out on a request, meaning clients
could wait forever waiting for a response.

This updates client configuration to respect per-service timeouts, as
well as setting a baseline timeout for all clients.

I set this to 5s just as a sample default; we use 6 seconds on the proxy level, meaning we may see this error more often than we had before.

The errors from the gateways, however, is a tad cryptic:
```
{
  "data": {
    "user": null
  },
  "errors": [
    {
      "message": "timeout of 1000ms exceeded",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "user"
      ]
    }
  ]
}```