### PR TITLE
add request headers to open api error

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.0
+current_version = 0.14.0
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-openapi",
-    "version": "0.13.0",
+    "version": "0.14.0",
     "description": "Opinionated OpenAPI (Swagger) Client",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-openapi.git",

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
         "eslint-config-airbnb-base": "^12.1.0",
         "eslint-plugin-import": "^2.9.0",
         "jest": "^22.4.2"
+    },
+    "jest": {
+        "testURL": "http://localhost/"
     }
 }

--- a/src/__tests__/error.test.js
+++ b/src/__tests__/error.test.js
@@ -50,6 +50,7 @@ describe('buildError', () => {
         } catch (error) {
             expect(error.code).toEqual('error');
             expect(error.data).toEqual(null);
+            expect(error.headers).toEqual(null);
         }
     });
 
@@ -77,6 +78,28 @@ describe('buildError', () => {
         } catch (error) {
             expect(error.code).toEqual(200);
             expect(error.message).toEqual('id');
+            expect(error.headers).toEqual(null);
+        }
+    });
+
+    it('return error with headers', () => {
+        try {
+            buildError()({
+                request: {
+                    getHeaders: () => ({
+                        'x-foo': 100,
+                        'x-bar': 200,
+                    }),
+                },
+            });
+            throw new Error('no error thrown');
+        } catch (error) {
+            expect(error.code).toEqual(null);
+            expect(error.data).toEqual(null);
+            expect(error.headers).toEqual(expect.objectContaining({
+                'x-foo': 100,
+                'x-bar': 200,
+            }));
         }
     });
 });

--- a/src/error.js
+++ b/src/error.js
@@ -8,12 +8,13 @@ import {
 } from 'http-status-codes';
 
 export class OpenAPIError extends Error {
-    constructor(message = null, code = 500, data = null) {
+    constructor(message = null, code = 500, data = null, headers = null) {
         super(message);
         Error.captureStackTrace(this, this.constructor);
         this.name = this.constructor.name;
         this.code = code;
         this.data = data;
+        this.headers = headers;
     }
 }
 
@@ -45,8 +46,10 @@ export function normalizeError(error) {
     const data = get(error, 'response.data', null);
     const message = get(data, 'message') || get(error, 'message', null);
     const code = get(data, 'code') || get(error, 'response.status') || get(error, 'code', null);
+    const req = get(error, 'request', null);
+    const headers = req && req.getHeaders ? req.getHeaders() : null;
 
-    return new OpenAPIError(message, code, data);
+    return new OpenAPIError(message, code, data, headers);
 }
 
 


### PR DESCRIPTION
Added request headers to `OpenAPIError`. This is to better contextualize the error which clients may wish to use it.