### PR TITLE
Use path args only in path

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.14.0
+current_version = 0.15.0
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-openapi",
-    "version": "0.14.0",
+    "version": "0.15.0",
     "description": "Opinionated OpenAPI (Swagger) Client",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-openapi.git",

--- a/src/__tests__/example.json
+++ b/src/__tests__/example.json
@@ -158,6 +158,13 @@
               "name": "chatroom_id",
               "required": true,
               "type": "string"
+            },
+            {
+              "format": "uuid",
+              "in": "query",
+              "name": "project_id",
+              "required": false,
+              "type": "string"
             }
           ],
           "responses": {

--- a/src/__tests__/request.test.js
+++ b/src/__tests__/request.test.js
@@ -63,4 +63,32 @@ describe('buildRequest', () => {
             url: 'http://localhost/api/v2/chatroom',
         });
     });
+
+    it('Make sure we are not passing the same argument as both query parameter and body argument', () => {
+        const context = {
+            spec,
+            path: '/chatroom/{chatroom_id}',
+            method: 'get',
+        };
+        const req = null;
+        expect(
+            buildRequest(context, req, {
+                chatroomId: 'bar',
+                projectId: 'baz',
+            }),
+        ).toEqual({
+            adapter: null,
+            data: null,
+            headers: {
+                'Content-Type': 'application/json; charset=utf-8',
+            },
+            maxContentLength: -1,
+            method: 'get',
+            params: {
+                project_id: 'baz',
+            },
+            timeout: 5000,
+            url: 'http://localhost/api/v2/chatroom/bar',
+        });
+    });
 });


### PR DESCRIPTION
Before:
We always passed path args `chatroom/{chatroomId}` as an param arg as well - `chatroom/{chatroomId}?chatroom_id={chatroomId}`

Now:
If an arg is passed as an path arg - don't use it as param arg at all (similar to microcosm). There are limitations here: if we do want to pass the arg. However, in this case, one can replace one of the `builders`. 


Alternative approach:
Update `buildParams` to be strict as marshmallow 3.0 and silently (or not silently) discard path args based on the swagger def. @afallou had some ideas about that.
I think it's preferable approach but would require more changes in nodule-openapi and will open the discussion about strict schema uses. I would prefer to continue in this path later.