### PR TITLE
explicit mockResponse

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.15.0
+current_version = 0.15.1
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-openapi",
-    "version": "0.15.0",
+    "version": "0.15.1",
     "description": "Opinionated OpenAPI (Swagger) Client",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-openapi.git",

--- a/src/clients/__tests__/openapi.test.js
+++ b/src/clients/__tests__/openapi.test.js
@@ -42,9 +42,9 @@ describe('createOpenAPIClient', () => {
         });
     });
 
-    it('supports mocking a response with a function', async () => {
+    it('supports mocking a response with a function based on params', async () => {
         const config = await Nodule.testing().fromObject(
-            mockResponse('petstore', 'pet.search', ({ name }) => ({ items: [name] })),
+            mockResponse('petstore', 'pet.search', ({ params }) => ({ items: [params.name] })),
         ).load();
 
         const client = createOpenAPIClient('petstore', spec);
@@ -62,9 +62,26 @@ describe('createOpenAPIClient', () => {
         });
     });
 
+    it('supports mocking a response with a function based on url', async () => {
+        const config = await Nodule.testing().fromObject(
+            mockResponse('petstore', 'pet.retrieve', ({ url }) => ({ id: url.split('pet/')[1] })),
+        ).load();
+
+        const client = createOpenAPIClient('petstore', spec);
+
+        const result = await client.pet.retrieve(req, { petId: 'pet-id' });
+        expect(result).toEqual({
+            id: 'pet-id',
+        });
+
+        expect(config.clients.mock.petstore.pet.retrieve).toHaveBeenCalledTimes(1);
+    });
+
     it('supports mocking a post response with a function', async () => {
         const config = await Nodule.testing().fromObject(
-            mockResponse('petstore', 'pet.create', body => ({ items: [body.name] })),
+            mockResponse('petstore', 'pet.create', ({ data }) => ({
+                items: [JSON.parse(data).name],
+            })),
         ).load();
 
         const client = createOpenAPIClient('petstore', spec);

--- a/src/clients/__tests__/openapi.test.js
+++ b/src/clients/__tests__/openapi.test.js
@@ -44,7 +44,7 @@ describe('createOpenAPIClient', () => {
 
     it('supports mocking a response with a function based on params', async () => {
         const config = await Nodule.testing().fromObject(
-            mockResponse('petstore', 'pet.search', ({ params }) => ({ items: [params.name] })),
+            mockResponse('petstore', 'pet.search', params => ({ items: [params.name] })),
         ).load();
 
         const client = createOpenAPIClient('petstore', spec);
@@ -64,7 +64,7 @@ describe('createOpenAPIClient', () => {
 
     it('supports mocking a response with a function based on url', async () => {
         const config = await Nodule.testing().fromObject(
-            mockResponse('petstore', 'pet.retrieve', ({ url }) => ({ id: url.split('pet/')[1] })),
+            mockResponse('petstore', 'pet.retrieve', (_, url) => ({ id: url.split('pet/')[1] })),
         ).load();
 
         const client = createOpenAPIClient('petstore', spec);
@@ -79,8 +79,8 @@ describe('createOpenAPIClient', () => {
 
     it('supports mocking a post response with a function', async () => {
         const config = await Nodule.testing().fromObject(
-            mockResponse('petstore', 'pet.create', ({ data }) => ({
-                items: [JSON.parse(data).name],
+            mockResponse('petstore', 'pet.create', body => ({
+                items: [body.name],
             })),
         ).load();
 

--- a/src/testing/openapi.js
+++ b/src/testing/openapi.js
@@ -9,7 +9,7 @@ export function mockResponse(name, operationId, data, headers = { 'content-type'
     const obj = {};
 
     set(obj, `clients.mock.${name}.${operationId}`, jest.fn(async req => ({
-        data: isFunction(data) ? data(req) : data,
+        data: isFunction(data) ? data(req.params || JSON.parse(req.data || null), req.url) : data,
         headers,
     })));
 

--- a/src/testing/openapi.js
+++ b/src/testing/openapi.js
@@ -9,7 +9,7 @@ export function mockResponse(name, operationId, data, headers = { 'content-type'
     const obj = {};
 
     set(obj, `clients.mock.${name}.${operationId}`, jest.fn(async req => ({
-        data: isFunction(data) ? data(req.params || JSON.parse(req.data || null)) : data,
+        data: isFunction(data) ? data(req) : data,
         headers,
     })));
 

--- a/src/testing/petstore.json
+++ b/src/testing/petstore.json
@@ -24,7 +24,7 @@
     "application/json"
   ],
   "paths": {
-    "/pets": {
+    "/pet": {
       "get": {
         "description": "Returns all pets from the system that the user has access to",
         "operationId": "search",
@@ -82,6 +82,33 @@
         },
         "tags": [
           "pet"
+        ]
+      }
+    },
+    "/pet/{pet_id}": {
+      "get": {
+        "operationId": "retrieve",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path", 
+            "name": "pet_id", 
+            "required": true, 
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A pet.",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        },
+        "tags": [
+            "pet"
         ]
       }
     }


### PR DESCRIPTION
For better or worse, `mockResponse` mocks a http response - not the nodule-openapi response.
Sometimes, when we want to control the mock response - we're using http mock request.
So far - we've used only `params` or `data`. But now, it seems that we also the url.

This PR will allow the `mockResponse` to use an optional url field. It won't break the existing api.