### PR TITLE
Configured timeout

### DIFF
--- a/src/__tests__/request.builders.test.js
+++ b/src/__tests__/request.builders.test.js
@@ -1,3 +1,4 @@
+import { Nodule } from '@globality/nodule-config';
 import spec from './example.json';
 import {
     buildData,
@@ -162,6 +163,19 @@ describe('buildTimeout', () => {
             buildTimeout(context),
         ).toEqual(
             1000,
+        );
+    });
+    it('accepts a configured timeout', async () => {
+        await Nodule.testing().fromObject({
+            defaultTimeout: '2000',
+        }).load();
+        const context = {
+            spec,
+        };
+        expect(
+            buildTimeout(context),
+        ).toEqual(
+            2000,
         );
     });
 });

--- a/src/request.js
+++ b/src/request.js
@@ -1,5 +1,6 @@
 /* Request building.
  */
+import { getConfig } from '@globality/nodule-config';
 import {
     capitalize,
     get,
@@ -10,6 +11,9 @@ import {
 } from 'lodash';
 
 import nameFor from './naming';
+
+
+const DEFAULT_TIMEOUT = 5000;
 
 
 /* Build request JSON data.
@@ -107,7 +111,15 @@ export function buildUrl(context, req, args) {
 }
 
 export function buildTimeout(context) {
-    return parseInt(get(context, 'options.timeout', 5000), 10);
+    const contextTimeout = get(context, 'options.timeout');
+    if (contextTimeout) {
+        return parseInt(contextTimeout, 10);
+    }
+    const configTimeout = getConfig('defaultTimeout');
+    if (configTimeout) {
+        return parseInt(configTimeout, 10);
+    }
+    return DEFAULT_TIMEOUT;
 }
 
 


### PR DESCRIPTION
Allow to configure every app default timeout instead of using hardcoded 5000ms
Especially relevant when debugging GWs on a slow network