### PR TITLE
GLOB-37084 Add automatic retries on failures

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
           "exports": "always-multiline",
           "functions": "always-multiline"
         }],
+        "no-plusplus": [2, { "allowForLoopAfterthoughts": true }],
         "function-paren-newline": ["error", "consistent"],
         "object-curly-newline": ["error", {"consistent": true}],
         "indent": ["error", 4, { "SwitchCase": 1 }],

--- a/src/__tests__/request.builders.test.js
+++ b/src/__tests__/request.builders.test.js
@@ -1,10 +1,11 @@
-import { Nodule } from '@globality/nodule-config';
+import { Nodule, clearBinding } from '@globality/nodule-config';
 import spec from './example.json';
 import {
     buildData,
     buildHeaders,
     buildMethod,
     buildParams,
+    buildRetries,
     buildTimeout,
     buildUrl,
     expandPath,
@@ -166,6 +167,7 @@ describe('buildTimeout', () => {
         );
     });
     it('accepts a configured timeout', async () => {
+        clearBinding();
         await Nodule.testing().fromObject({
             defaultTimeout: '2000',
         }).load();
@@ -176,6 +178,47 @@ describe('buildTimeout', () => {
             buildTimeout(context),
         ).toEqual(
             2000,
+        );
+    });
+});
+
+describe('buildRetries', () => {
+    it('constructs retries', () => {
+        const context = {
+            spec,
+            path: '/foo',
+        };
+        expect(
+            buildRetries(context),
+        ).toEqual(
+            0,
+        );
+    });
+    it('accepts override retries', () => {
+        const context = {
+            spec,
+            options: {
+                retries: 5,
+            },
+        };
+        expect(
+            buildRetries(context),
+        ).toEqual(
+            5,
+        );
+    });
+    it('accepts configured retries', async () => {
+        clearBinding('config');
+        await Nodule.testing().fromObject({
+            defaultRetries: '10',
+        }).load();
+        const context = {
+            spec,
+        };
+        expect(
+            buildRetries(context),
+        ).toEqual(
+            10,
         );
     });
 });

--- a/src/__tests__/request.builders.test.js
+++ b/src/__tests__/request.builders.test.js
@@ -167,7 +167,7 @@ describe('buildTimeout', () => {
         );
     });
     it('accepts a configured timeout', async () => {
-        clearBinding();
+        clearBinding('config');
         await Nodule.testing().fromObject({
             defaultTimeout: '2000',
         }).load();

--- a/src/__tests__/request.test.js
+++ b/src/__tests__/request.test.js
@@ -27,7 +27,7 @@ describe('buildRequest', () => {
             maxContentLength: -1,
             method: 'post',
             params: null,
-            retries: 3,
+            retries: 0,
             timeout: 5000,
             url: 'http://localhost/api/v2/chatroom',
         });
@@ -60,7 +60,7 @@ describe('buildRequest', () => {
             maxContentLength: -1,
             method: 'post',
             params: null,
-            retries: 3,
+            retries: 0,
             timeout: 5000,
             url: 'http://localhost/api/v2/chatroom',
         });
@@ -89,7 +89,7 @@ describe('buildRequest', () => {
             params: {
                 project_id: 'baz',
             },
-            retries: 3,
+            retries: 0,
             timeout: 5000,
             url: 'http://localhost/api/v2/chatroom/bar',
         });

--- a/src/__tests__/request.test.js
+++ b/src/__tests__/request.test.js
@@ -27,6 +27,7 @@ describe('buildRequest', () => {
             maxContentLength: -1,
             method: 'post',
             params: null,
+            retries: 3,
             timeout: 5000,
             url: 'http://localhost/api/v2/chatroom',
         });
@@ -59,6 +60,7 @@ describe('buildRequest', () => {
             maxContentLength: -1,
             method: 'post',
             params: null,
+            retries: 3,
             timeout: 5000,
             url: 'http://localhost/api/v2/chatroom',
         });
@@ -87,6 +89,7 @@ describe('buildRequest', () => {
             params: {
                 project_id: 'baz',
             },
+            retries: 3,
             timeout: 5000,
             url: 'http://localhost/api/v2/chatroom/bar',
         });

--- a/src/clients/__tests__/openapi.test.js
+++ b/src/clients/__tests__/openapi.test.js
@@ -97,9 +97,7 @@ describe('createOpenAPIClient', () => {
     it('supports mocking errors', async () => {
         const config = await Nodule.testing().fromObject(
             mockError('petstore', 'pet.search', 'Not Found', 404),
-        ).fromObject({
-            defaultRetries: 1,
-        }).load();
+        ).load();
 
         const client = createOpenAPIClient('petstore', spec);
 
@@ -141,9 +139,7 @@ describe('createOpenAPIClient', () => {
             mockResponse('petstore', 'pet.search', '', {
                 'content-type': 'text/html',
             }),
-        ).fromObject({
-            defaultRetries: 1,
-        }).load();
+        ).load();
 
         const client = createOpenAPIClient('petstore', spec);
 

--- a/src/clients/__tests__/openapi.test.js
+++ b/src/clients/__tests__/openapi.test.js
@@ -97,7 +97,9 @@ describe('createOpenAPIClient', () => {
     it('supports mocking errors', async () => {
         const config = await Nodule.testing().fromObject(
             mockError('petstore', 'pet.search', 'Not Found', 404),
-        ).load();
+        ).fromObject({
+            defaultRetries: 1,
+        }).load();
 
         const client = createOpenAPIClient('petstore', spec);
 
@@ -139,7 +141,9 @@ describe('createOpenAPIClient', () => {
             mockResponse('petstore', 'pet.search', '', {
                 'content-type': 'text/html',
             }),
-        ).load();
+        ).fromObject({
+            defaultRetries: 1,
+        }).load();
 
         const client = createOpenAPIClient('petstore', spec);
 

--- a/src/clients/openapi.js
+++ b/src/clients/openapi.js
@@ -134,7 +134,7 @@ export function http(req, serviceName, operationName) {
 export function createOpenAPIClient(name, spec) {
     const metadata = getMetadata();
     const config = getConfig(`clients.${name}`) || {};
-    const { baseUrl, timeout } = config;
+    const { baseUrl, timeout, retries } = config;
 
     if (!baseUrl && !metadata.testing && !metadata.debug) {
         throw new Error(`OpenAPI client ${name} does not have a configured baseUrl`);
@@ -146,6 +146,7 @@ export function createOpenAPIClient(name, spec) {
         buildHeaders,
         http,
         timeout,
+        retries,
     };
     return OpenAPI(spec, name, options);
 }

--- a/src/operation.js
+++ b/src/operation.js
@@ -48,7 +48,7 @@ export default (context, name, operationName) => async (req, args, options) => {
             );
         } catch (error) {
             if (logger) {
-                logger.warning(req, `API request failed; attempt ${attempt}`);
+                logger.warning(req, `API request failed; attempt ${attempt + 1}`);
             }
             errorResponse = error;
         }

--- a/src/request.js
+++ b/src/request.js
@@ -14,6 +14,7 @@ import nameFor from './naming';
 
 
 const DEFAULT_TIMEOUT = 5000;
+const DEFAULT_RETRIES = 3;
 
 
 /* Build request JSON data.
@@ -122,6 +123,18 @@ export function buildTimeout(context) {
     return DEFAULT_TIMEOUT;
 }
 
+export function buildRetries(context) {
+    const contextRetries = get(context, 'options.retries');
+    if (contextRetries) {
+        return parseInt(contextRetries, 10);
+    }
+    const configRetries = getConfig('defaultRetries');
+    if (configRetries) {
+        return parseInt(configRetries, 10);
+    }
+    return DEFAULT_RETRIES;
+}
+
 
 /* Build base request (to be overridden by other builders).
  */
@@ -149,6 +162,7 @@ const DEFAULT_BUILDERS = {
     data: buildData,
     params: buildParams,
     timeout: buildTimeout,
+    retries: buildRetries,
 };
 
 

--- a/src/request.js
+++ b/src/request.js
@@ -14,7 +14,7 @@ import nameFor from './naming';
 
 
 const DEFAULT_TIMEOUT = 5000;
-const DEFAULT_RETRIES = 3;
+const DEFAULT_RETRIES = 0;
 
 
 /* Build request JSON data.


### PR DESCRIPTION
Under times of high load, we may run into situations where a given
service fails due to some kind of transient issue (e.g. a misbehaving
service instance). In those cases, we can be proactive about retrying
that request, instead of immediately surfacing up an error to the GW/FE.

Note: I'm aware that this is a bit of a heavy hammer. We can discuss
about whether or not this is the right thing to do.

This would most likely also need to be accompanied with longer styx request timeouts; under the current default scheme, we'll end up waiting 15s before erroring out.

Alternatively, we could decrease the default timeout, and retry quicker.