### PR TITLE
GLOB-37351 Improve error retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,13 @@ In pseudo-code:
 
 The `nodule-openapi` includes a function (createOpenAPIClient) that allows the wrapping of the OpenAPI
 swagger client into callable functions. See the README in the src/clients for more information.
+
+## Retries
+
+Clients can additionally be configured to automatically retry failed requests, after having met some criteria to qualify
+it as retryable:
+
+* The raised error is retryable (e.g. 50x response codes, client exceptions)
+* The operation itself is retryable. As of this writing, this will only include read operations
+
+By default, retries are not enabled.


### PR DESCRIPTION
Updates error retries such that:
* Known non-retryable methods are discarded from consideration
* Does not retry errors that aren't retryable
* Failure attempts actually log the failed operation

Also: update the README.

Note: the second bullet point *hasn't* been added yet; I need to do some
more debugging into expected error structure to know what I can/can't
expect. In the meantime, I've added tests to make sure they're
eventually considered.