### PR TITLE
enable pagination for body requests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ export {
 } from './error';
 export {
     all,
+    allForBodySearchRequest,
     any,
     concurrentPaginate,
     first,

--- a/src/modules/__tests__/pagingBody.test.js
+++ b/src/modules/__tests__/pagingBody.test.js
@@ -1,0 +1,57 @@
+import { range } from 'lodash';
+import { allForBodySearchRequest } from '../paging';
+
+const items = range(100).map(id => ({ id }));
+const req = {};
+let searchRequest;
+
+describe('Pagination', () => {
+
+    beforeEach(() => {
+        searchRequest = jest.fn(async (_, { body: { limit = 20, offset = 0 } }) => ({
+            count: items.length,
+            items: items.slice(offset, offset + limit),
+            limit,
+            offset,
+        }));
+    });
+
+    it('test search all items', async () => {
+        const res = await allForBodySearchRequest(req, { searchRequest, body: { limit: 40 } });
+        expect(res).toEqual(items);
+
+        expect(searchRequest).toHaveBeenCalledTimes(3);
+        expect(searchRequest).toHaveBeenCalledWith(req, {
+            body: {
+                offset: 0,
+                limit: 40,
+            },
+        });
+        expect(searchRequest).toHaveBeenCalledWith(req, {
+            body: {
+                offset: 40,
+                limit: 40,
+            },
+        });
+        expect(searchRequest).toHaveBeenCalledWith(req, {
+            body: {
+                offset: 80,
+                limit: 40,
+            },
+        });
+    });
+
+    it('test search items passes params', async () => {
+        const res = await allForBodySearchRequest(req, { searchRequest, body: { limit: 200, param: 'eter' } });
+        expect(res).toEqual(items);
+
+        expect(searchRequest).toHaveBeenCalledTimes(1);
+        expect(searchRequest).toHaveBeenCalledWith(req, {
+            body: {
+                offset: 0,
+                limit: 200,
+                param: 'eter',
+            },
+        });
+    });
+});

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -1,5 +1,6 @@
 export {
     all,
+    allForBodySearchRequest,
     any,
     first,
     none,

--- a/src/modules/paging/all.js
+++ b/src/modules/paging/all.js
@@ -6,7 +6,17 @@ import concurrentPaginate from '../concurrency';
 const DEFAULT_LIMIT = 20;
 
 /**
- * Pagination for search requests that takes parameters in the body (for example in batch endpoints)
+ * Pagination for search requests that expect parameters to be passed in the body.
+ * For example:
+ * GET https://service.env.globality.io/api/resource/batch
+ * Content-Type: application/json; charset=UTF-8
+ * {
+ *     "identifiers": ["ID1", "ID2"... "ID1000"],
+ *     "limit": 20,
+ *     "offset": 0
+ * }
+ * A typical use case is for batch requests that send a long list of identifiers as a parameter
+ * In this case searching via URL query is not possible because of URL length limit
  * @body search requests args. Can optionally contain initial 'limit' and 'offset' values
  */
 export async function allForBodySearchRequest(

--- a/src/modules/paging/all.js
+++ b/src/modules/paging/all.js
@@ -1,4 +1,4 @@
-import { flatten, range, isNil, isEmpty } from 'lodash';
+import { flatten, range, isNil } from 'lodash';
 import { getConfig } from '@globality/nodule-config';
 import { MaxLimitReached } from '../../error';
 import concurrentPaginate from '../concurrency';
@@ -9,7 +9,7 @@ const DEFAULT_LIMIT = 20;
  * Pagination for search requests that takes parameters in the body (for example in batch endpoints)
  * @body search requests args. Can optionally contain initial 'limit' and 'offset' values
  */
-export default async function allForBodySearchRequest(
+export async function allForBodySearchRequest(
     req,
     { searchRequest, body = {}, maxLimit = null, concurrencyLimit = 1 },
 ) {

--- a/src/modules/paging/all.js
+++ b/src/modules/paging/all.js
@@ -1,9 +1,10 @@
-import { flatten, range, isNil } from 'lodash';
+import { flatten, range, isNil, isEmpty } from 'lodash';
 import { getConfig } from '@globality/nodule-config';
 import { MaxLimitReached } from '../../error';
 import concurrentPaginate from '../concurrency';
 
 const DEFAULT_LIMIT = 20;
+
 function buildSearchRequestParams(searchArgs, limit, offset, sendBodyToSearchRequest) {
     // Deliver params according to target search request - in args or in body
     const paramsValues = {
@@ -15,12 +16,12 @@ function buildSearchRequestParams(searchArgs, limit, offset, sendBodyToSearchReq
     return paramsWrapper;
 }
 
-async function all(
+export default async function all(
     req,
     { searchRequest, args = {}, body = null, maxLimit = null, concurrencyLimit = 1 },
 ) {
     if (!isEmpty(args) && !isEmpty(body)) {
-        throw new BadRequest('all() function handles either args or body, no support for both yet');
+        throw new Error('all() function handles either args or body, no support for both yet');
     }
     const sendBodyToSearchRequest = body != null;
     const paramsSource = sendBodyToSearchRequest ? body : args;

--- a/src/modules/paging/index.js
+++ b/src/modules/paging/index.js
@@ -1,4 +1,5 @@
 export { default as all } from './all';
+export { allForBodySearchRequest } from './all';
 export { default as any } from './any';
 export { default as first } from './first';
 export { default as none } from './none';


### PR DESCRIPTION
### Why?
Enabling pagination of search requests that expect parameters as body
For example:
```
GET https://service.env.globality.io/api/resource/batch
Content-Type: application/json; charset=UTF-8
{
    "identifiers": ["ID1", "ID2"... "ID1000"],
    "limit": 20,
    "offset": 0
}
```
As opposed to:
```
GET https://service.env.globality.io/api/resource?identifiers=['ID1','ID2',...'ID9000']&limit=20&offset=0
```
A typical use case is to batch requests that take a long list of identifiers as a parameter
In this case searching via URL query is not possible because of URL length limit, resulting is 414 URI too long error

### How?
Currently `all()` paging function only supports search request that expect pagination parameters in URL query (as in the second example above)
Adding a new function  `allForBodySearchRequest()` to support body search requests (as in the first example above)

### Usage Example:
```
const results = allForBodySearchRequest(req, {
        searchRequest: service.resource.search,
        body: {
            identifiers: idsList,
        },
    });
```