### PR TITLE
GLOB-49581: Added configuration to override parameter naming

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,8 @@ jobs:
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "yarn.lock" }}
-          - v1-dependencies-
+          # Removing this for now. We can enable partial cache again after the major upgrade is in to avoid causing other branches' build to fail
+          # - v1-dependencies-
 
       - run:
           name: Install Dependencies

--- a/src/__tests__/naming.test.js
+++ b/src/__tests__/naming.test.js
@@ -1,9 +1,10 @@
-import {
+import { get } from 'lodash';
+import naming, {
     operationNameFor,
     pathParameterNameFor,
     queryParameterNameFor,
+    NAMING_OPTION,
 } from '../naming';
-
 
 describe('operationNameFor', () => {
     it('converts to camelCase', () => {
@@ -82,6 +83,44 @@ describe('queryParameterNameFor', () => {
             queryParameterNameFor('foo_bar', true),
         ).toEqual(
             'foo_bar',
+        );
+    });
+});
+
+describe('overrides', () => {
+    it('accepts an override', () => {
+        const overrides = {
+            path: get(NAMING_OPTION, 'preserveParameterName'),
+            query: get(NAMING_OPTION, 'preserveParameterName'),
+        };
+
+        const context = {
+            options: {
+                naming: {
+                    ...overrides,
+                },
+            },
+        };
+        const options = get(context, 'options', {});
+        expect(
+            naming('companyId', 'query', true, options),
+        ).toEqual(
+            'companyId',
+        );
+        expect(
+            naming('company_id', 'query', true, options),
+        ).toEqual(
+            'company_id',
+        );
+        expect(
+            naming('companyId', 'path', true, options),
+        ).toEqual(
+            'companyId',
+        );
+        expect(
+            naming('company_id', 'path', true, options),
+        ).toEqual(
+            'company_id',
         );
     });
 });

--- a/src/clients/openapi.js
+++ b/src/clients/openapi.js
@@ -3,6 +3,7 @@ import { get } from 'lodash';
 import { getConfig, getMetadata, getContainer } from '@globality/nodule-config';
 import axios from 'axios';
 import OpenAPI from '../client';
+import { NAMING_OPTION } from '../naming';
 
 /* Inject mock and testing adapters.
  */
@@ -134,11 +135,16 @@ export function http(req, serviceName, operationName) {
 export function createOpenAPIClient(name, spec) {
     const metadata = getMetadata();
     const config = getConfig(`clients.${name}`) || {};
-    const { baseUrl, timeout, retries } = config;
+    const { baseUrl, timeout, retries, namingOverride, namingPath, namingQuery } = config;
 
     if (!baseUrl && !metadata.testing && !metadata.debug) {
         throw new Error(`OpenAPI client ${name} does not have a configured baseUrl`);
     }
+
+    const naming = namingOverride ? {
+        path: get(NAMING_OPTION, namingPath),
+        query: get(NAMING_OPTION, namingQuery),
+    } : {};
 
     const options = {
         baseUrl,
@@ -147,6 +153,7 @@ export function createOpenAPIClient(name, spec) {
         http,
         timeout,
         retries,
+        naming,
     };
     return OpenAPI(spec, name, options);
 }

--- a/src/naming.js
+++ b/src/naming.js
@@ -37,12 +37,21 @@ export function queryParameterNameFor(value, fromUser) {
     return fromUser ? snakeCase(value) : camelCase(value);
 }
 
+/* Preserve parameter name
+ *
+ */
+const preserveParameterName = value => value;
 
 const DEFAULT_NAMING = {
     path: pathParameterNameFor,
     query: queryParameterNameFor,
 };
 
+const NAMING_OPTION = {
+    preserveParameterName,
+    pathParameterNameFor,
+    queryParameterNameFor,
+};
 
 /* Resolve the name for something.
  */
@@ -51,3 +60,5 @@ export default (name, type, fromUser, options) => {
     const nameFor = get(overrides, type, DEFAULT_NAMING[type]);
     return nameFor ? nameFor(name, fromUser) : name;
 };
+
+exports.NAMING_OPTION = NAMING_OPTION;


### PR DESCRIPTION
To support Java based read service which uses camel case naming convention, we need to introduce new configuration set at the service level to override the default naming convention.

Sample configuration:
STYX__CLIENTS__READSERVICE__NAMING_OVERRIDE=true STYX__CLIENTS__READSERVICE__NAMING_PATH=preserveParameterName
STYX__CLIENTS__READSERVICE__NAMING_QUERY=preserveParameterName