### PR TITLE
Add validation warning to paging.all

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "scripts": {
         "build": "babel src --out-dir lib --ignore '**/__tests__/*,**/__mocks__/*'",
         "lint": "eslint src --cache",
-        "test": "jest src",
+        "test": "jest -w 1",
         "verify": "yarn lint && yarn test"
     },
     "dependencies": {

--- a/src/modules/__tests__/paging.test.js
+++ b/src/modules/__tests__/paging.test.js
@@ -2,11 +2,13 @@ import { range } from 'lodash';
 import { all, any, one, none, first } from '../paging';
 
 const items = range(100).map(id => ({ id }));
+const largeItems = range(201).map(id => ({ id }));
 const req = {};
 let searchRequest;
 let searchRequestNone;
 let searchRequestOne;
 let searchRequestTwo;
+let searchLargeDataSet;
 
 describe('Pagination', () => {
 
@@ -29,6 +31,12 @@ describe('Pagination', () => {
             count: 2,
             items: [{ id: 1 }, { id: 2 }],
         }));
+        searchLargeDataSet = jest.fn(async (_, { limit = 20, offset = 0 }) => ({
+            count: largeItems.length,
+            items: largeItems.slice(offset, offset + limit),
+            limit,
+            offset,
+        }));
     });
 
     it('test search all items', async () => {
@@ -48,6 +56,12 @@ describe('Pagination', () => {
             offset: 80,
             limit: 40,
         });
+    });
+
+    it('test search all items with large dataset logs warning', async () => {
+        const res = await all(req, { searchRequest: searchLargeDataSet, args: { limit: 20 } });
+        expect(res).toEqual(largeItems);
+        expect(searchLargeDataSet).toHaveBeenCalledTimes(11);
     });
 
     it('test search items passes params', async () => {

--- a/src/modules/__tests__/paging.test.js
+++ b/src/modules/__tests__/paging.test.js
@@ -10,6 +10,21 @@ let searchRequestOne;
 let searchRequestTwo;
 let searchLargeDataSet;
 
+const mockWarning = jest.fn();
+jest.mock('@globality/nodule-config', () => ({
+    getMetadata: () => ({
+        testing: false,
+    }),
+    bind: () => {},
+    setDefaults: () => {},
+    getConfig: () => null,
+    getContainer: () => ({
+        logger: {
+            warning: mockWarning,
+        },
+    }),
+}));
+
 describe('Pagination', () => {
 
     beforeEach(() => {
@@ -62,6 +77,16 @@ describe('Pagination', () => {
         const res = await all(req, { searchRequest: searchLargeDataSet, args: { limit: 20 } });
         expect(res).toEqual(largeItems);
         expect(searchLargeDataSet).toHaveBeenCalledTimes(11);
+        expect(mockWarning).toHaveBeenCalledTimes(1);
+        expect(mockWarning).toHaveBeenCalledWith(
+            req,
+            'A large dataset requested with default limit set.',
+            {
+                numResults: 201,
+                searchParam: {},
+                searchRequest: searchLargeDataSet,
+            },
+        );
     });
 
     it('test search items passes params', async () => {


### PR DESCRIPTION
**What?**
add warning log when large dataset returned with default page_size

**Why?**
To help find cases where we are fetching large sets of data in small increments.