### PR TITLE
[GLOB-51977] Pass the JWT along with request headers in Open API Client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,7 @@ defaults: &defaults
     - image: circleci/node:8.11.3
 
 whitelist: &whitelist
-  paths:
-    .
+  paths: .
 
 version: 2
 jobs:
@@ -18,10 +17,12 @@ jobs:
       - run:
           name: Authenticate NPM
           command: |
-            echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
+            touch .npmrc
+            curl -u$JFROG_AUTH https://globality.jfrog.io/globality/api/npm/auth > .npmrc
+            echo "registry=https://globality.jfrog.io/globality/api/npm/npm" >> .npmrc
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "yarn.lock" }}
+            - v1-dependencies-{{ checksum "yarn.lock" }}
           # Removing this for now. We can enable partial cache again after the major upgrade is in to avoid causing other branches' build to fail
           # - v1-dependencies-
 
@@ -79,6 +80,19 @@ jobs:
           root: ~/repo
           <<: *whitelist
 
+  deploy_rc:
+    <<: *defaults
+
+    steps:
+      - attach_workspace:
+          at: ~/repo
+
+      - run:
+          name: Publish to NPM
+          command: |
+            sed  -i '/version/s/[^.]*$/'"0-dev${CIRCLE_BUILD_NUM}\",/" package.json
+            npm publish
+
   deploy:
     <<: *defaults
 
@@ -96,38 +110,43 @@ workflows:
   build:
     jobs:
       - checkout:
-          context: 
-          - Globality-Common
+          context:
+            - Globality-Common
       - lint:
-          context: 
-          - Globality-Common
+          context:
+            - Globality-Common
           requires:
             - checkout
       - test:
-          context: 
-          - Globality-Common
+          context:
+            - Globality-Common
           requires:
             - checkout
       - build:
-          context: 
-          - Globality-Common
+          context:
+            - Globality-Common
           requires:
             - lint
             - test
+      - deploy_rc:
+          context:
+            - Globality-Common
+          requires:
+            - build
 
   release:
     jobs:
       - checkout:
-          context: 
-          - Globality-Common
+          context:
+            - Globality-Common
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*/
             branches:
               ignore: /.*/
       - lint:
-          context: 
-          - Globality-Common
+          context:
+            - Globality-Common
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*/
@@ -136,8 +155,8 @@ workflows:
           requires:
             - checkout
       - test:
-          context: 
-          - Globality-Common
+          context:
+            - Globality-Common
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*/
@@ -146,8 +165,8 @@ workflows:
           requires:
             - checkout
       - build:
-          context: 
-          - Globality-Common
+          context:
+            - Globality-Common
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*/
@@ -156,8 +175,8 @@ workflows:
           requires:
             - test
       - deploy:
-          context: 
-          - Globality-Common
+          context:
+            - Globality-Common
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*/

--- a/src/clients/README.md
+++ b/src/clients/README.md
@@ -27,6 +27,7 @@ If a given function is not specified, the code defaults to the following set of 
 * X-Request-Id: Taken from `req.id`
 * X-Request-Started-At: Taken from `req._startAt` or the current datetime
 * X-Request-User: Taken from `req.locals.user.id`
+* Jwt: A JSON stringifed representation of `req.locals.jwt`
 
 ## Logging
 

--- a/src/clients/openapi.js
+++ b/src/clients/openapi.js
@@ -50,8 +50,10 @@ function defaultExtendHeaders(req, headers) {
     }
 
     // pass the jwt
-    const jwt = get(req, 'locals.jwt');
-    extendHeaders.jwt = JSON.stringify(jwt);
+    const jwt = get(req, 'cookies.idToken');
+    if (jwt) {
+        extendHeaders.Authorization = `Bearer ${jwt}`;
+    }
 
     return Object.assign(headers, extendHeaders);
 }

--- a/src/clients/openapi.js
+++ b/src/clients/openapi.js
@@ -1,9 +1,9 @@
-import { get } from 'lodash';
-
-import { getConfig, getMetadata, getContainer } from '@globality/nodule-config';
+import { getConfig, getContainer, getMetadata } from '@globality/nodule-config';
 import axios from 'axios';
+import { get } from 'lodash';
 import OpenAPI from '../client';
 import { NAMING_OPTION } from '../naming';
+
 
 /* Inject mock and testing adapters.
  */
@@ -48,6 +48,10 @@ function defaultExtendHeaders(req, headers) {
     if (userId) {
         extendHeaders['X-Request-User'] = userId;
     }
+
+    // pass the jwt
+    const jwt = get(req, 'locals.jwt');
+    extendHeaders.jwt = JSON.stringify(jwt);
 
     return Object.assign(headers, extendHeaders);
 }


### PR DESCRIPTION
https://globality.atlassian.net/browse/GLOB-51977


Seems to do what we want - passes the jwt through with any request provided it's in the request locals.

I will, of course, revert the circle config changes - I needed them so I could prepare a styx branch using this version of nodule-openapi to deploy to an environment (so I could be sure the JWT wasn't coming through in any logs).

I haven't managed to assert whether or not it'll get logged in sentry (working on this now)

It's not showing up in logs.