### PR TITLE
feature/DEVOPS-3439-publish_lib_to_jfrog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:8.11.3
+    - image: circleci/node:14.15.4
 
 whitelist: &whitelist
   paths: .
@@ -20,9 +20,7 @@ jobs:
             echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "yarn.lock" }}
-          # Removing this for now. We can enable partial cache again after the major upgrade is in to avoid causing other branches' build to fail
-          # - v1-dependencies-
+          - v1-dependencies-{{ checksum "yarn.lock" }}
 
       - run:
           name: Install Dependencies
@@ -78,7 +76,20 @@ jobs:
           root: ~/repo
           <<: *whitelist
 
-  deploy:
+  deploy_rc:
+    <<: *defaults
+
+    steps:
+      - attach_workspace:
+          at: ~/repo
+
+      - run:
+          name: Publish to NPM
+          command: |
+            sed  -i '/version/s/[^.]*$/'"0-dev${CIRCLE_BUILD_NUM}\",/" package.json
+            npm publish
+
+  publish_library_to_npmjs:
     <<: *defaults
 
     steps:
@@ -88,6 +99,20 @@ jobs:
       - run:
           name: Publish to NPM
           command: npm publish
+
+  publish_library_to_jfrog:
+    <<: *defaults
+
+    steps:
+      - attach_workspace:
+          at: ~/repo
+
+      - run:
+          name: Publish to JFrog
+          command: |
+            curl -s -u$JFROG_AUTH https://globality.jfrog.io/globality/api/npm/auth > .npmrc
+            echo "registry=https://globality.jfrog.io/globality/api/npm/npm"       >> .npmrc
+            npm publish
 
 workflows:
   version: 2
@@ -113,6 +138,11 @@ workflows:
           requires:
             - lint
             - test
+      - deploy_rc:
+          context:
+            - Globality-Common
+          requires:
+            - build
 
   release:
     jobs:
@@ -154,7 +184,17 @@ workflows:
               ignore: /.*/
           requires:
             - test
-      - deploy:
+      - publish_library_to_npmjs:
+          context:
+            - Globality-Common
+          filters:
+            tags:
+              only: /[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/
+          requires:
+            - build
+      - publish_library_to_jfrog:
           context:
             - Globality-Common
           filters:

--- a/.globality/build.json
+++ b/.globality/build.json
@@ -1,7 +1,11 @@
 {
-  "type": "node-module",
   "params": {
+    "extra_publication": {
+      "jfrog": true
+    },
     "name": "nodule-openapi",
     "open_source": true
-  }
+  },
+  "type": "node-module",
+  "version": "2021.10.0"
 }


### PR DESCRIPTION
per https://globality.atlassian.net/browse/DEVOPS-3439, this PR is to allow library package publication to both of NPMJS and JFrog.  Upon merge to master as a final validations, I will have a PR against Globality-build to update the corresponding nodule-module templates.

By adding the following inside params of build.json, globality-build can update the nodule-module template to allow package publication to jfrog.  By leaving this section out or setting jfrog to false and re-run globality-build, it will remove the publication to Jfrog.

>    "extra_publication": {
>      "jfrog": true
>    },

