### PR TITLE
feature/DEVOPS-3439-bump_version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.19.3
+current_version = 0.19.4
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-openapi",
-    "version": "0.19.3",
+    "version": "0.19.4",
     "description": "Opinionated OpenAPI (Swagger) Client",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-openapi.git",


### PR DESCRIPTION
This PR is to bump the version from 0.19.3 to 0.19.4 with the goal as a validation of library publication to both of NPMJS and JFrog.