### PR TITLE
Prune Auth Headers from OpenAPIError Object

### DIFF
--- a/src/__tests__/error.test.js
+++ b/src/__tests__/error.test.js
@@ -102,4 +102,25 @@ describe('buildError', () => {
             }));
         }
     });
+
+    it('prunes authorization information from headers', () => {
+        try {
+            buildError()({
+                request: {
+                    getHeaders: () => ({
+                        'x-foo': 100,
+                        'x-bar': 200,
+                        'Authorization': 'baz',
+                        'authorization': 'baz',
+                    }),
+                },
+            });
+            throw new Error('no error thrown');
+        } catch (error) {
+            expect(error.headers).toEqual(expect.objectContaining({
+                'x-foo': 100,
+                'x-bar': 200,
+            }));
+        }
+    });
 });

--- a/src/__tests__/error.test.js
+++ b/src/__tests__/error.test.js
@@ -110,8 +110,8 @@ describe('buildError', () => {
                     getHeaders: () => ({
                         'x-foo': 100,
                         'x-bar': 200,
-                        'Authorization': 'baz',
-                        'authorization': 'baz',
+                        Authorization: 'baz',
+                        aUthOriZation: 'baz',
                     }),
                 },
             });

--- a/src/error.js
+++ b/src/error.js
@@ -1,11 +1,22 @@
 /* Error handling.
  */
-import { get } from 'lodash';
 import {
+    GATEWAY_TIMEOUT,
     INTERNAL_SERVER_ERROR,
     NOT_FOUND,
-    GATEWAY_TIMEOUT,
 } from 'http-status-codes';
+import { get, omit } from 'lodash';
+
+// We are accidentally leaking auth headers to loggly when throwing
+// an OpenAPIError. We want to fix this properly in the long term,
+// but as a short term solution we are simply going to omit the headers
+// from the error here. This operation is case insensitive.
+function pruneAuthorizationHeaders(headers) {
+    if (!headers || !Object.keys(headers).map(key => key.toLowerCase()).includes('authorization')) {
+        return headers;
+    }
+    return omit(headers, ['authorization', 'Authorization']);
+}
 
 export class OpenAPIError extends Error {
     constructor(message = null, code = 500, data = null, headers = null) {
@@ -14,7 +25,7 @@ export class OpenAPIError extends Error {
         this.name = this.constructor.name;
         this.code = code;
         this.data = data;
-        this.headers = headers;
+        this.headers = pruneAuthorizationHeaders(headers);
     }
 }
 

--- a/src/error.js
+++ b/src/error.js
@@ -5,17 +5,19 @@ import {
     INTERNAL_SERVER_ERROR,
     NOT_FOUND,
 } from 'http-status-codes';
-import { get, omit } from 'lodash';
+import { get, omitBy } from 'lodash';
 
 // We are accidentally leaking auth headers to loggly when throwing
 // an OpenAPIError. We want to fix this properly in the long term,
 // but as a short term solution we are simply going to omit the headers
 // from the error here. This operation is case insensitive.
 function pruneAuthorizationHeaders(headers) {
-    if (!headers || !Object.keys(headers).map(key => key.toLowerCase()).includes('authorization')) {
+    if (!headers) {
         return headers;
     }
-    return omit(headers, ['authorization', 'Authorization']);
+
+    const disallowed = ['authorization'];
+    return omitBy(headers, (val, key) => disallowed.includes(key.toLowerCase().trim()));
 }
 
 export class OpenAPIError extends Error {


### PR DESCRIPTION
We recently discovered we are leaking auth headers to Loggly.

Currently, the surface area of this is still fairly small, but
obviously not ideal. An ideal infosec turnaround would be <48 hours
to fix this - which is why we are opting to prune auth headers from
the error headers attribute.

In the longer term, we would like to look at re-architecting
nodule-logging, but currently the library is untested and the risk of
contagion from making a risky change in that library is HIGH.

So, in this commit, we make sure to look for both Authorization and
authorization keys in the headers object, and if we find them, we use
lodash's omit() function (chosen because it preserves the original
headers object) to remove them.