### PR TITLE
Retry proxy errors by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-openapi",
-    "version": "0.19.6",
+    "version": "0.20.0",
     "description": "Opinionated OpenAPI (Swagger) Client",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-openapi.git",

--- a/src/__tests__/request.test.js
+++ b/src/__tests__/request.test.js
@@ -28,6 +28,7 @@ describe('buildRequest', () => {
             method: 'post',
             params: null,
             retries: 0,
+            proxyRetries: 3,
             timeout: 5000,
             url: 'http://localhost/api/v2/chatroom',
         });
@@ -39,6 +40,8 @@ describe('buildRequest', () => {
             path: '/chatroom',
             method: 'post',
             options: {
+                retries: 5,
+                proxyRetries: 6,
                 buildHeaders: () => ({ baz: 'qux' }),
             },
         };
@@ -60,7 +63,8 @@ describe('buildRequest', () => {
             maxContentLength: -1,
             method: 'post',
             params: null,
-            retries: 0,
+            retries: 5,
+            proxyRetries: 6,
             timeout: 5000,
             url: 'http://localhost/api/v2/chatroom',
         });
@@ -91,6 +95,7 @@ describe('buildRequest', () => {
             },
             retries: 0,
             timeout: 5000,
+            proxyRetries: 3,
             url: 'http://localhost/api/v2/chatroom/bar',
         });
     });

--- a/src/__tests__/request.test.js
+++ b/src/__tests__/request.test.js
@@ -28,7 +28,7 @@ describe('buildRequest', () => {
             method: 'post',
             params: null,
             retries: 0,
-            proxyRetries: 3,
+            proxyRetries: 0,
             timeout: 5000,
             url: 'http://localhost/api/v2/chatroom',
         });
@@ -95,7 +95,7 @@ describe('buildRequest', () => {
             },
             retries: 0,
             timeout: 5000,
-            proxyRetries: 3,
+            proxyRetries: 0,
             url: 'http://localhost/api/v2/chatroom/bar',
         });
     });

--- a/src/clients/__tests__/openapi.test.js
+++ b/src/clients/__tests__/openapi.test.js
@@ -213,4 +213,50 @@ describe('createOpenAPIClient', () => {
 
         expect(config.clients.mock.petstore.pet.search).toHaveBeenCalledTimes(3);
     });
+
+    it('retries read operations on proxy error', async () => {
+        const config = await Nodule.testing().fromObject(
+            mockError('petstore', 'pet.search', 'Service Unavailable', 503),
+        ).load();
+
+        const client = createOpenAPIClient('petstore', spec);
+
+        await expect(client.pet.search(req)).rejects.toThrow(
+            'Service Unavailable',
+        );
+
+        expect(config.clients.mock.petstore.pet.search).toHaveBeenCalledTimes(4);
+    });
+
+    it('retries write operations on proxy error', async () => {
+        const config = await Nodule.testing().fromObject(
+            mockError('petstore', 'pet.create', 'Service Unavailable', 503),
+        ).fromObject({
+            defaultProxyRetries: 2,
+        }).load();
+
+        const client = createOpenAPIClient('petstore', spec);
+
+        await expect(client.pet.create(req)).rejects.toThrow(
+            'Service Unavailable',
+        );
+
+        expect(config.clients.mock.petstore.pet.create).toHaveBeenCalledTimes(3);
+    });
+
+    it('retries operations using maximum number of retries on proxy errors', async () => {
+        const config = await Nodule.testing().fromObject(
+            mockError('petstore', 'pet.search', 'Not Implemented', 501),
+        ).fromObject({
+            defaultRetries: 5,
+        }).load();
+
+        const client = createOpenAPIClient('petstore', spec);
+
+        await expect(client.pet.search(req)).rejects.toThrow(
+            'Not Implemented',
+        );
+
+        expect(config.clients.mock.petstore.pet.search).toHaveBeenCalledTimes(6);
+    });
 });

--- a/src/clients/__tests__/openapi.test.js
+++ b/src/clients/__tests__/openapi.test.js
@@ -217,7 +217,9 @@ describe('createOpenAPIClient', () => {
     it('retries read operations on proxy error', async () => {
         const config = await Nodule.testing().fromObject(
             mockError('petstore', 'pet.search', 'Service Unavailable', 503),
-        ).load();
+        ).fromObject({
+            defaultProxyRetries: 3,
+        }).load();
 
         const client = createOpenAPIClient('petstore', spec);
 
@@ -248,6 +250,7 @@ describe('createOpenAPIClient', () => {
         const config = await Nodule.testing().fromObject(
             mockError('petstore', 'pet.search', 'Not Implemented', 501),
         ).fromObject({
+            defaultProxyRetries: 2,
             defaultRetries: 5,
         }).load();
 

--- a/src/request.js
+++ b/src/request.js
@@ -15,7 +15,7 @@ import nameFor from './naming';
 
 const DEFAULT_TIMEOUT = 5000;
 const DEFAULT_RETRIES = 0;
-const DEFAULT_PROXY_RETRIES = 3;
+const DEFAULT_PROXY_RETRIES = 0;
 
 
 /* Build request JSON data.

--- a/src/request.js
+++ b/src/request.js
@@ -15,6 +15,7 @@ import nameFor from './naming';
 
 const DEFAULT_TIMEOUT = 5000;
 const DEFAULT_RETRIES = 0;
+const DEFAULT_PROXY_RETRIES = 3;
 
 
 /* Build request JSON data.
@@ -137,6 +138,18 @@ export function buildRetries(context) {
     return DEFAULT_RETRIES;
 }
 
+export function buildProxyRetries(context) {
+    const contextProxyRetries = get(context, 'options.proxyRetries');
+    if (contextProxyRetries) {
+        return parseInt(contextProxyRetries, 10);
+    }
+    const configProxyRetries = getConfig('defaultProxyRetries');
+    if (configProxyRetries) {
+        return parseInt(configProxyRetries, 10);
+    }
+    return DEFAULT_PROXY_RETRIES;
+}
+
 
 /* Build base request (to be overridden by other builders).
  */
@@ -165,6 +178,7 @@ const DEFAULT_BUILDERS = {
     params: buildParams,
     timeout: buildTimeout,
     retries: buildRetries,
+    proxyRetries: buildProxyRetries,
 };
 
 


### PR DESCRIPTION
As requested on [GLOB-61753] we want, by default, retry 501 and 503 errors reported by HAProxy. 

PR enabling proxy retries on Styx: https://github.com/globality-corp/ansible-deploy/pull/4003

[GLOB-61753]: https://globality.atlassian.net/browse/GLOB-61753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ