### PR TITLE
Consolidate logs at the operation level

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-openapi",
-    "version": "0.21.0",
+    "version": "0.22.0",
     "description": "Opinionated OpenAPI (Swagger) Client",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-openapi.git",


### PR DESCRIPTION
Move logging to the operation level and consolidate with retry logs,
with the overall success (or not) of the operation headlining.

Retry information is included as structured properties of the log line.

This makes it easier to find requests that ended in end-client failure
while still allowing analysis of whether retry configuration is needed
or succesful.