### PR TITLE
Adding camelCase fix for operation name

### DIFF
--- a/src/__tests__/openApiCodeGenClients/utils.test.js
+++ b/src/__tests__/openApiCodeGenClients/utils.test.js
@@ -110,6 +110,7 @@ describe('capitalizeFirstLetter', () => {
 describe('convertOperationIdToOperationName', () => {
     it.each([
         ['partial_api_public_v1_cheesy_pizza_get', 'partialApiPublicV1CheesyPizzaGet'],
+        ['downloadLink', 'downloadLink'],
     ])('correctly converts operation id to operation name', (input, expectedOutput) => {
         const output = convertOperationIdToOperationName(input);
         expect(output).toEqual(expectedOutput);

--- a/src/openApiCodeGenClients/utils.js
+++ b/src/openApiCodeGenClients/utils.js
@@ -1,4 +1,4 @@
-import { includes, isNil, lowerCase } from 'lodash';
+import { camelCase, includes, isNil, lowerCase } from 'lodash';
 
 
 export function isMutationOperation(requestMethod) {
@@ -72,11 +72,8 @@ export function capitalizeFirstLetter(string) {
 export function convertOperationIdToOperationName(operationId) {
     // e.g operationId = partial_api_public_v1_cheesy_pizza_get
     // associated operation would then be: partialApiPublicV1CheesyPizzaGet
-    const operationWords = operationId.split('_');
-    const upperCased = operationWords.map(name => capitalizeFirstLetter(name));
 
-    // lower case first word in the array e.g Public -> public
-    upperCased[0] = upperCased[0].toLowerCase();
-
-    return upperCased.join('');
+    // e.g operationId = downloadLink
+    // associated operation name would be: downloadLink
+    return camelCase(operationId);
 }


### PR DESCRIPTION
Need to update the openapi nodule adapter to deal with camelCase operationIds.

We had originally assumed that operationIds would only be `snake_case`.

Have updated the implementation to deal with both cases and add extra test coverage.