### PR TITLE
GLOB-75641: Fix improper handling of empty data

### DIFF
--- a/src/__tests__/example.json
+++ b/src/__tests__/example.json
@@ -184,6 +184,32 @@
           "tags": [
             "chatroom"
           ]
+        },
+        "delete": {
+          "operationId": "delete",
+          "parameters": [
+            {
+              "format": "uuid",
+              "in": "path",
+              "name": "chatroom_id",
+              "required": true,
+              "type": "string"
+            }
+          ],
+          "responses": {
+            "204": {
+              "description": "Delete a chatroom by id"
+            },
+            "default": {
+              "description": "An error occurred",
+              "schema": {
+                "$ref": "#/definitions/Error"
+              }
+            }
+          },
+          "tags": [
+            "chatroom"
+          ]
         }
       }
     },

--- a/src/__tests__/openapi.test.js
+++ b/src/__tests__/openapi.test.js
@@ -11,6 +11,7 @@ describe('OpenAPI initialization', () => {
                 create: expect.anything(),
                 retrieve: expect.anything(),
                 search: expect.anything(),
+                delete: expect.anything(),
             },
         });
     });
@@ -27,6 +28,17 @@ describe('OpenAPI invocation', () => {
 
         const client = OpenAPI(spec, 'test', options);
         const result = await client.chatroom.search();
+        expect(result).toEqual(data);
+    });
+    it('handles empty data', async () => {
+        const data = '';
+
+        const options = {
+            adapter: () => Promise.resolve({ data }),
+        };
+
+        const client = OpenAPI(spec, 'test', options);
+        const result = await client.chatroom.delete(undefined, { chatroomId: 1 });
         expect(result).toEqual(data);
     });
     it('raises error', async () => {

--- a/src/operation.js
+++ b/src/operation.js
@@ -127,7 +127,7 @@ export default (context, name, operationName) => async (req, args, options) => {
         requestLogs.serviceErrorsCount = serviceErrorsCount;
     }
 
-    if (successResponse) {
+    if (successResponse !== undefined) {
         if (logSuccess) {
             logSuccess(req, request, rawResponse, requestLogs, executeStartTime);
         }


### PR DESCRIPTION
## Why ?

OpenAPI client provided by `nodule-openapi` is unable to properly handle empty response from successful `delete` operation. Currently, it treats such response as error and tries to parse it, so this error is raised:

```
    OpenAPIError: null

      63 |     const headers = req && req.getHeaders ? req.getHeaders() : null;
      64 | 
    > 65 |     return new OpenAPIError(message, code, data, headers);
         |            ^
      66 | }
      67 | 
      68 | 

      at normalizeError (src/error.js:65:12)
```

Closes https://globality.atlassian.net/browse/GLOB-75641

## What ?

- Reworked condition checking if there's success response to treat as success everything except `undefined`
- Added unit test
