### PR TITLE
[GLOB-75773] Adding support for client header + passing in additional request headers explicitly

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.27.0
+current_version = 0.28.0
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-openapi",
-    "version": "0.27.0",
+    "version": "0.28.0",
     "description": "Opinionated OpenAPI (Swagger) Client",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-openapi.git",

--- a/src/__tests__/operation.test.js
+++ b/src/__tests__/operation.test.js
@@ -1,0 +1,63 @@
+import { extendHeadersFromOptions } from '../operation';
+
+describe('extendHeadersFromOptions function', () => {
+
+    it('should merge request.headers with options.additionalHeaders', () => {
+        const request = {
+            url: 'https://example.com/api',
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: 'Bearer someToken',
+            },
+        };
+
+        const options = {
+            additionalHeaders: {
+                'X-Custom-Header': 'CustomValue',
+                'X-Another-Header': 'AnotherValue',
+            },
+        };
+
+        const expectedHeaders = {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer someToken',
+            'X-Custom-Header': 'CustomValue',
+            'X-Another-Header': 'AnotherValue',
+        };
+
+
+        const { headers } = extendHeadersFromOptions(request, options);
+        expect(headers).toEqual(expectedHeaders);
+    });
+
+    it('should return the same request if options.additionalHeaders does not exist', () => {
+        const request = {
+            url: 'https://example.com/api',
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: 'Bearer someToken',
+            },
+        };
+
+        const options = {};
+
+        const result = extendHeadersFromOptions(request, options);
+        expect(result).toEqual(request);
+    });
+
+    it('should return the same request if options is not provided', () => {
+        const request = {
+            url: 'https://example.com/api',
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: 'Bearer someToken',
+            },
+        };
+
+        const result = extendHeadersFromOptions(request);
+        expect(result).toEqual(request);
+    });
+});

--- a/src/clients/README.md
+++ b/src/clients/README.md
@@ -25,7 +25,7 @@ If a given function is not specified, the code defaults to the following set of 
 
 * X-Request-Service: Taken from `getMetadata().name`
 * X-Request-Id: Taken from `req.id`
-* X-Request-Started-At: Taken from `req._startAt` or the current datetime
+* X-Request-Started-At: Taken from `req._startTime` or the current datetime
 * X-Request-User: Taken from `req.locals.user.id`
 * Jwt: A JSON stringifed representation of `req.locals.jwt`
 

--- a/src/clients/__tests__/openapi.test.js
+++ b/src/clients/__tests__/openapi.test.js
@@ -247,4 +247,40 @@ describe('createOpenAPIClient', () => {
 
         expect(config.clients.mock.petstore.pet.create).toHaveBeenCalledTimes(3);
     });
+
+    it('adds x-request-client header', async () => {
+        const config = await Nodule.testing().fromObject(
+            mockResponse('petstore', 'pet.search', {
+                items: [
+                    REX,
+                ],
+            }),
+        ).load();
+
+        const client = createOpenAPIClient('petstore', spec);
+
+        const req2 = {
+            id: 'request-id',
+            locals: {
+                user: {
+                    clientId: 'client-id-123',
+                },
+            },
+        };
+        const result = await client.pet.search(req2);
+        expect(result).toEqual({
+            items: [
+                REX,
+            ],
+        });
+
+        expect(config.clients.mock.petstore.pet.search).toHaveBeenCalledTimes(1);
+        expect(config.clients.mock.petstore.pet.search.mock.calls[0][0].headers).toMatchObject({
+            Accept: 'application/json, text/plain, */*',
+            'Content-Type': 'application/json; charset=utf-8',
+            'X-Request-Service': 'test',
+            'X-Request-Id': 'request-id',
+            'X-Request-Client': 'client-id-123',
+        });
+    });
 });

--- a/src/clients/__tests__/openapi.test.js
+++ b/src/clients/__tests__/openapi.test.js
@@ -283,4 +283,33 @@ describe('createOpenAPIClient', () => {
             'X-Request-Client': 'client-id-123',
         });
     });
+
+    it('Adds additional headers from options', async () => {
+        const config = await Nodule.testing().fromObject(
+            mockResponse('petstore', 'pet.search', {
+                items: [
+                    'abc',
+                ],
+            }),
+        ).load();
+
+        const client = createOpenAPIClient('petstore', spec);
+
+        const result = await client.pet.search(req, { name: 'abc' }, {
+            additionalHeaders: {
+                'X-Request-Test': 'test',
+            },
+        });
+        expect(result).toEqual({
+            items: ['abc'],
+        });
+
+        expect(config.clients.mock.petstore.pet.search).toHaveBeenCalledTimes(1);
+        expect(config.clients.mock.petstore.pet.search.mock.calls[0][0].headers).toMatchObject({
+            Accept: 'application/json, text/plain, */*',
+            'Content-Type': 'application/json; charset=utf-8',
+            'X-Request-Service': 'test',
+            'X-Request-Test': 'test',
+        });
+    });
 });

--- a/src/clients/openapi.js
+++ b/src/clients/openapi.js
@@ -52,6 +52,7 @@ function defaultExtendHeaders(req, headers) {
     }
 
     // pass the client id from the user (if any)
+    // this is so we can identify which client is making the request
     const clientId = get(req, 'locals.user.clientId');
     if (clientId) {
         extendHeaders['X-Request-Client'] = clientId;

--- a/src/clients/openapi.js
+++ b/src/clients/openapi.js
@@ -51,6 +51,12 @@ function defaultExtendHeaders(req, headers) {
         extendHeaders['X-Request-User'] = userId;
     }
 
+    // pass the current user (if any)
+    const tenantId = get(req, 'locals.user.tenantId');
+    if (tenantId) {
+        extendHeaders['X-Request-Tenant-Id'] = tenantId;
+    }
+
     // pass the jwt
     const jwt = get(req, 'cookies.idToken');
     if (jwt) {

--- a/src/clients/openapi.js
+++ b/src/clients/openapi.js
@@ -51,7 +51,7 @@ function defaultExtendHeaders(req, headers) {
         extendHeaders['X-Request-User'] = userId;
     }
 
-    // pass the current user (if any)
+    // pass the tenant id from the user (if any)
     const tenantId = get(req, 'locals.user.tenantId');
     if (tenantId) {
         extendHeaders['X-Request-Tenant-Id'] = tenantId;

--- a/src/clients/openapi.js
+++ b/src/clients/openapi.js
@@ -51,10 +51,10 @@ function defaultExtendHeaders(req, headers) {
         extendHeaders['X-Request-User'] = userId;
     }
 
-    // pass the tenant id from the user (if any)
-    const tenantId = get(req, 'locals.user.tenantId');
-    if (tenantId) {
-        extendHeaders['X-Request-Tenant-Id'] = tenantId;
+    // pass the client id from the user (if any)
+    const clientId = get(req, 'locals.user.clientId');
+    if (clientId) {
+        extendHeaders['X-Request-Client'] = clientId;
     }
 
     // pass the jwt

--- a/src/modules/__tests__/paging.test.js
+++ b/src/modules/__tests__/paging.test.js
@@ -15,8 +15,8 @@ jest.mock('@globality/nodule-config', () => ({
     getMetadata: () => ({
         testing: false,
     }),
-    bind: () => {},
-    setDefaults: () => {},
+    bind: () => { },
+    setDefaults: () => { },
     getConfig: () => null,
     getContainer: () => ({
         logger: {
@@ -55,6 +55,45 @@ describe('Pagination', () => {
     });
 
     it('test search all items', async () => {
+        const res = await all(req, {
+            searchRequest,
+            args: { limit: 40 },
+            options: {
+                additionalHeaders: {
+                    'x-test-header': 'test',
+                },
+            },
+        });
+        expect(res).toEqual(items);
+
+        expect(searchRequest).toHaveBeenCalledTimes(3);
+        expect(searchRequest).toHaveBeenCalledWith(req, {
+            offset: 0,
+            limit: 40,
+        }, {
+            additionalHeaders: {
+                'x-test-header': 'test',
+            },
+        });
+        expect(searchRequest).toHaveBeenCalledWith(req, {
+            offset: 40,
+            limit: 40,
+        }, {
+            additionalHeaders: {
+                'x-test-header': 'test',
+            },
+        });
+        expect(searchRequest).toHaveBeenCalledWith(req, {
+            offset: 80,
+            limit: 40,
+        }, {
+            additionalHeaders: {
+                'x-test-header': 'test',
+            },
+        });
+    });
+
+    it('test search all items: with additional headers', async () => {
         const res = await all(req, { searchRequest, args: { limit: 40 } });
         expect(res).toEqual(items);
 
@@ -62,15 +101,15 @@ describe('Pagination', () => {
         expect(searchRequest).toHaveBeenCalledWith(req, {
             offset: 0,
             limit: 40,
-        });
+        }, {});
         expect(searchRequest).toHaveBeenCalledWith(req, {
             offset: 40,
             limit: 40,
-        });
+        }, {});
         expect(searchRequest).toHaveBeenCalledWith(req, {
             offset: 80,
             limit: 40,
-        });
+        }, {});
     });
 
     it('test search all items with large dataset logs warning', async () => {
@@ -98,7 +137,7 @@ describe('Pagination', () => {
             offset: 0,
             limit: 200,
             param: 'eter',
-        });
+        }, {});
     });
 
     it('test none', async () => {
@@ -108,7 +147,7 @@ describe('Pagination', () => {
         expect(searchRequestNone).toHaveBeenCalledTimes(1);
         expect(searchRequestNone).toHaveBeenCalledWith(req, {
             param: 'eter',
-        });
+        }, {});
     });
 
     it('test none: too many results', async () => {
@@ -124,7 +163,7 @@ describe('Pagination', () => {
         expect(searchRequestTwo).toHaveBeenCalledTimes(1);
         expect(searchRequestTwo).toHaveBeenCalledWith(req, {
             param: 'eter',
-        });
+        }, {});
     });
 
     it('test one', async () => {
@@ -134,6 +173,30 @@ describe('Pagination', () => {
         expect(searchRequestOne).toHaveBeenCalledTimes(1);
         expect(searchRequestOne).toHaveBeenCalledWith(req, {
             param: 'eter',
+        }, {});
+    });
+
+    it('test one: with additional headers', async () => {
+        const res = await one(
+            req,
+            {
+                searchRequest: searchRequestOne,
+                args: { param: 'eter' },
+                options: {
+                    additionalHeaders: {
+                        'x-test-header': 'test',
+                    },
+                },
+            },
+        );
+        expect(res).toEqual({ id: 1 });
+
+        expect(searchRequestOne).toHaveBeenCalledTimes(1);
+        expect(searchRequestOne).toHaveBeenCalledWith(req, {
+            param: 'eter',
+
+        }, {
+            additionalHeaders: { 'x-test-header': 'test' },
         });
     });
 
@@ -150,7 +213,7 @@ describe('Pagination', () => {
         expect(searchRequestNone).toHaveBeenCalledTimes(1);
         expect(searchRequestNone).toHaveBeenCalledWith(req, {
             param: 'eter',
-        });
+        }, {});
     });
 
     it('test one: too many results', async () => {
@@ -166,7 +229,7 @@ describe('Pagination', () => {
         expect(searchRequestTwo).toHaveBeenCalledTimes(1);
         expect(searchRequestTwo).toHaveBeenCalledWith(req, {
             param: 'eter',
-        });
+        }, {});
     });
 
     it('test any: no results', async () => {
@@ -197,7 +260,7 @@ describe('Pagination', () => {
         expect(searchRequestNone).toHaveBeenCalledTimes(1);
         expect(searchRequestNone).toHaveBeenCalledWith(req, {
             param: 'eter',
-        });
+        }, {});
     });
 
 });

--- a/src/modules/__tests__/pagingBody.test.js
+++ b/src/modules/__tests__/pagingBody.test.js
@@ -26,19 +26,19 @@ describe('Pagination', () => {
                 offset: 0,
                 limit: 40,
             },
-        });
+        }, {});
         expect(searchRequest).toHaveBeenCalledWith(req, {
             body: {
                 offset: 40,
                 limit: 40,
             },
-        });
+        }, {});
         expect(searchRequest).toHaveBeenCalledWith(req, {
             body: {
                 offset: 80,
                 limit: 40,
             },
-        });
+        }, {});
     });
 
     it('test search items passes params', async () => {
@@ -52,6 +52,6 @@ describe('Pagination', () => {
                 limit: 200,
                 param: 'eter',
             },
-        });
+        }, {});
     });
 });

--- a/src/modules/paging/any.js
+++ b/src/modules/paging/any.js
@@ -1,4 +1,4 @@
-export default async function any(req, { searchRequest, args = {} }) {
-    const page = await searchRequest(req, args);
+export default async function any(req, { searchRequest, args = {}, options = {} }) {
+    const page = await searchRequest(req, args, options);
     return page.items.length > 0;
 }

--- a/src/modules/paging/first.js
+++ b/src/modules/paging/first.js
@@ -1,7 +1,7 @@
 import { NoResults } from '../../error';
 
-export default async function first(req, { searchRequest, args = {}, returnNullOnEmpty = false }) {
-    const page = await searchRequest(req, args);
+export default async function first(req, { searchRequest, args = {}, returnNullOnEmpty = false, options = {} }) {
+    const page = await searchRequest(req, args, options);
     if (page.items.length) {
         return page.items[0];
     }

--- a/src/modules/paging/first.js
+++ b/src/modules/paging/first.js
@@ -1,6 +1,8 @@
 import { NoResults } from '../../error';
 
-export default async function first(req, { searchRequest, args = {}, returnNullOnEmpty = false, options = {} }) {
+export default async function first(
+    req, { searchRequest, args = {}, returnNullOnEmpty = false, options = {} },
+) {
     const page = await searchRequest(req, args, options);
     if (page.items.length) {
         return page.items[0];

--- a/src/modules/paging/none.js
+++ b/src/modules/paging/none.js
@@ -1,7 +1,7 @@
 import { TooManyResults } from '../../error';
 
-export default async function none(req, { searchRequest, args = {} }) {
-    const page = await searchRequest(req, args);
+export default async function none(req, { searchRequest, args = {}, options = {} }) {
+    const page = await searchRequest(req, args, options);
     if (page.items.length) {
         throw new TooManyResults(`Too many results found for search: ${page.items.length}`);
     }

--- a/src/modules/paging/one.js
+++ b/src/modules/paging/one.js
@@ -1,7 +1,8 @@
 import { TooManyResults, NoResults } from '../../error';
 
-export default async function one(req, { searchRequest, args = {}, returnNullOnEmpty = false }) {
-    const page = await searchRequest(req, args);
+export default async function one(req,
+    { searchRequest, args = {}, returnNullOnEmpty = false, options = {} }) {
+    const page = await searchRequest(req, args, options);
     if (page.items.length === 1) {
         return page.items[0];
     }

--- a/src/openApiCodeGenClients/__test__/helpers.test.js
+++ b/src/openApiCodeGenClients/__test__/helpers.test.js
@@ -1,0 +1,86 @@
+import { createHeaders } from '../helpers';
+
+
+jest.mock('@globality/nodule-config', () => ({
+    getMetadata: () => ({
+        name: 'my-service',
+    }),
+    getContainer: () => { },
+}));
+
+describe('createHeaders function', () => {
+    it('should merge initialHeaders with options.additionalHeaders', () => {
+        const startTime = new Date('2023-08-18T10:15:03.052Z');
+        const req = {
+            id: 'request-id',
+            locals: {
+                user: {
+                    id: 'user-id',
+                },
+            },
+            _startTime: startTime,
+        };
+
+        const context = {
+            spec: {},
+            path: '/my-api',
+            method: 'post',
+            options: {
+                retries: 5,
+            },
+        };
+        const options = {
+            additionalHeaders: {
+                'X-Request-My-Specific-Header': 'id-123',
+            },
+        };
+
+        const expectedFinalHeaders = {
+            'Content-Type': 'application/json; charset=utf-8',
+            'X-Request-Service': 'my-service',
+            'X-Request-Started-At': '2023-08-18T10:15:03.052Z',
+            'X-Request-Id': 'request-id',
+            'X-Request-My-Specific-Header': 'id-123',
+            'X-Request-User': 'user-id',
+        };
+
+        const result = createHeaders(req, context, options);
+
+        expect(result).toEqual(expectedFinalHeaders);
+    });
+
+    it('should handle the absence of additionalHeaders property on options', () => {
+        const startTime = new Date('2023-08-18T10:15:03.052Z');
+        const req = {
+            id: 'request-id',
+            locals: {
+                user: {
+                    id: 'user-id',
+                },
+            },
+            _startTime: startTime,
+        };
+
+        const context = {
+            spec: {},
+            path: '/my-api',
+            method: 'post',
+            options: {
+                retries: 5,
+            },
+        };
+        const options = {}; // No additionalHeaders here
+
+        const expectedHeadersWithoutAdditionalHeaders = {
+            'Content-Type': 'application/json; charset=utf-8',
+            'X-Request-Service': 'my-service',
+            'X-Request-Started-At': '2023-08-18T10:15:03.052Z',
+            'X-Request-Id': 'request-id',
+            'X-Request-User': 'user-id',
+        };
+
+        const result = createHeaders(req, context, options);
+
+        expect(result).toEqual(expectedHeadersWithoutAdditionalHeaders);
+    });
+});

--- a/src/openApiCodeGenClients/__test__/operation.test.js
+++ b/src/openApiCodeGenClients/__test__/operation.test.js
@@ -28,6 +28,7 @@ describe('createOpenAPIClient', () => {
     };
 
     beforeEach(() => {
+        jest.clearAllMocks();
         clearBinding('config');
     });
 
@@ -47,6 +48,47 @@ describe('createOpenAPIClient', () => {
         });
         expect(spy).toHaveBeenCalledTimes(1);
         expect(spy.mock.calls[0][1].headers['X-Request-Id']).toBe('request-id');
+    });
+
+    it('passes proper x-request-client in header based on req data', async () => {
+        await Nodule.testing().load();
+
+        // First we need to reset spy
+        const spy = jest.spyOn(PetApi.prototype, 'search');
+        // spy.mockClear();
+
+        const client = createOpenAPIClientV2('petstore', { petApi: PetApi }, spec);
+        const result = await client.petApi.search(req);
+
+        expect(result).toEqual({
+            items: [
+                REX,
+            ],
+        });
+        expect(spy).toHaveBeenCalledTimes(1);
         expect(spy.mock.calls[0][1].headers['X-Request-Client']).toBe('client-id-123');
+    });
+
+    it('if no client id found then x-request-client header is not included', async () => {
+        await Nodule.testing().load();
+
+        const spy = jest.spyOn(PetApi.prototype, 'search');
+
+        const client = createOpenAPIClientV2('petstore', { petApi: PetApi }, spec);
+        const reqWithNoClientData = {
+            id: 'request-id',
+            locals: {
+                user: {},
+            },
+        };
+        const result = await client.petApi.search(reqWithNoClientData);
+
+        expect(result).toEqual({
+            items: [
+                REX,
+            ],
+        });
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy.mock.calls[0][1].headers['X-Request-Client']).toBe(undefined);
     });
 });

--- a/src/openApiCodeGenClients/__test__/operation.test.js
+++ b/src/openApiCodeGenClients/__test__/operation.test.js
@@ -17,7 +17,7 @@ describe('createOpenAPIClient', () => {
         id: 'request-id',
         locals: {
             user: {
-                tenantId: 'client-tenant-id-123',
+                clientId: 'client-id-123',
             },
         },
     };
@@ -47,6 +47,6 @@ describe('createOpenAPIClient', () => {
         });
         expect(spy).toHaveBeenCalledTimes(1);
         expect(spy.mock.calls[0][1].headers['X-Request-Id']).toBe('request-id');
-        expect(spy.mock.calls[0][1].headers['X-Request-Tenant-Id']).toBe('client-tenant-id-123');
+        expect(spy.mock.calls[0][1].headers['X-Request-Client']).toBe('client-id-123');
     });
 });

--- a/src/openApiCodeGenClients/__test__/operation.test.js
+++ b/src/openApiCodeGenClients/__test__/operation.test.js
@@ -15,6 +15,11 @@ class PetApi {
 describe('createOpenAPIClient', () => {
     const req = {
         id: 'request-id',
+        locals: {
+            user: {
+                tenantId: 'client-tenant-id-123',
+            },
+        },
     };
 
     const REX = {
@@ -42,5 +47,6 @@ describe('createOpenAPIClient', () => {
         });
         expect(spy).toHaveBeenCalledTimes(1);
         expect(spy.mock.calls[0][1].headers['X-Request-Id']).toBe('request-id');
+        expect(spy.mock.calls[0][1].headers['X-Request-Tenant-Id']).toBe('client-tenant-id-123');
     });
 });

--- a/src/openApiCodeGenClients/__test__/operation.test.js
+++ b/src/openApiCodeGenClients/__test__/operation.test.js
@@ -91,4 +91,32 @@ describe('createOpenAPIClient', () => {
         expect(spy).toHaveBeenCalledTimes(1);
         expect(spy.mock.calls[0][1].headers['X-Request-Client']).toBe(undefined);
     });
+
+    it('includes additional headers from options', async () => {
+        await Nodule.testing().load();
+
+        const spy = jest.spyOn(PetApi.prototype, 'search');
+
+        const client = createOpenAPIClientV2('petstore', { petApi: PetApi }, spec);
+        const reqWithNoClientData = {
+            id: 'request-id',
+            locals: {
+                user: {},
+            },
+        };
+        const result = await client.petApi.search(reqWithNoClientData, null, {
+            additionalHeaders: {
+                'X-Request-Test-Header': 'test',
+            },
+        });
+
+        expect(result).toEqual({
+            items: [
+                REX,
+            ],
+        });
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy.mock.calls[0][1].headers['X-Request-Client']).toBe(undefined);
+        expect(spy.mock.calls[0][1].headers['X-Request-Test-Header']).toBe('test');
+    });
 });

--- a/src/openApiCodeGenClients/helpers.js
+++ b/src/openApiCodeGenClients/helpers.js
@@ -10,9 +10,10 @@ function createHeaders(req, context, options) {
         context,
         req,
     );
+
     return {
         ...initialHeaders,
-        ...options.additionalHeaders,
+        ...(options && options.additionalHeaders ? options.additionalHeaders : {}),
     };
 }
 

--- a/src/openApiCodeGenClients/helpers.js
+++ b/src/openApiCodeGenClients/helpers.js
@@ -1,0 +1,38 @@
+import { buildHeaders } from '../clients/openapi';
+
+function createHeaders(req, context, options) {
+    /**
+     * Header creation function. Uses the build headers func and
+     * and then allows for the request specific options to override
+     * the initial headers
+     */
+    const initialHeaders = buildHeaders(
+        context,
+        req,
+    );
+    return {
+        ...initialHeaders,
+        ...options.additionalHeaders,
+    };
+}
+
+function createParamsWrapper(args) {
+    let paramsWrapper;
+    if (Array.isArray(args)) {
+        // Whilst args is an array we need to convert it to an object
+        paramsWrapper = {
+            params: args.reduce((a, v) => ({ ...a, [v]: v }), {}),
+        };
+    } else {
+        // assuming args is an object (i.e next gen typescript api client generation)
+        paramsWrapper = {
+            params: args,
+        };
+    }
+    return paramsWrapper;
+}
+
+export {
+    createHeaders,
+    createParamsWrapper,
+};

--- a/src/openApiCodeGenClients/operation.js
+++ b/src/openApiCodeGenClients/operation.js
@@ -2,7 +2,7 @@
  */
 import { getContainer } from '@globality/nodule-config/lib';
 import { assign, get } from 'lodash';
-import { buildAdapter, buildHeaders } from '../clients/openapi';
+import { buildAdapter } from '../clients/openapi';
 import buildError, { normalizeError } from '../error';
 import { isRetryableOperation } from '../operation';
 import buildResponse from '../response';

--- a/src/openApiCodeGenClients/operation.js
+++ b/src/openApiCodeGenClients/operation.js
@@ -6,22 +6,8 @@ import { buildAdapter, buildHeaders } from '../clients/openapi';
 import buildError, { normalizeError } from '../error';
 import { isRetryableOperation } from '../operation';
 import buildResponse from '../response';
+import { createHeaders, createParamsWrapper } from './helpers';
 
-function createParamsWrapper(args) {
-    let paramsWrapper;
-    if (Array.isArray(args)) {
-        // Whilst args is an array we need to convert it to an object
-        paramsWrapper = {
-            params: args.reduce((a, v) => ({ ...a, [v]: v }), {}),
-        };
-    } else {
-        // assuming args is an object (i.e next gen typescript api client generation)
-        paramsWrapper = {
-            params: args,
-        };
-    }
-    return paramsWrapper;
-}
 
 /* Create a new callable operation that return a Promise.
  */
@@ -44,10 +30,7 @@ export default (
             name: serviceName,
             operationName,
         }),
-        headers: buildHeaders(
-            context,
-            req,
-        ),
+        headers: createHeaders(req, context, options),
     };
 
     const { buildRequestLogs, logSuccess, logFailure } = getContainer('logging') || {};

--- a/src/operation.js
+++ b/src/operation.js
@@ -50,6 +50,23 @@ export function isRetryableOperation(openApiError) {
     );
 }
 
+export function extendHeadersFromOptions(request, options) {
+    /**
+     * Extend request headers based on the addtional headers
+     * passed in via the options object
+     */
+    if (options && options.additionalHeaders) {
+        return {
+            ...request,
+            headers: {
+                ...request.headers,
+                ...options.additionalHeaders,
+            },
+        };
+    }
+    return request;
+}
+
 /* Create a new callable operation that return a Promise.
  */
 export default (context, name, operationName) => async (req, args, options) => {
@@ -65,12 +82,16 @@ export default (context, name, operationName) => async (req, args, options) => {
         operationName,
     });
 
-    const request = buildRequest(
+    let request = buildRequest(
         requestContext,
         req,
         args,
         options,
     );
+
+    // Extend headers from options
+    // Allows for passing in specific headers for a given request
+    request = extendHeadersFromOptions(request, options);
 
     const { buildRequestLogs, logSuccess, logFailure } = getContainer('logging') || {};
 


### PR DESCRIPTION
We want to start populating X-Request-Client onto request headers.

Note that we only populate if we find the `user.clientId` field.

Also adds support to specifically set request headers if required.