### PR TITLE
Fixed empty response

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.26.0
+current_version = 0.27.0
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-openapi",
-    "version": "0.26.0",
+    "version": "0.27.0",
     "description": "Opinionated OpenAPI (Swagger) Client",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-openapi.git",

--- a/src/openApiCodeGenClients/operation.js
+++ b/src/openApiCodeGenClients/operation.js
@@ -118,7 +118,7 @@ export default (
     if (requestLogs) {
         requestLogs.failureMessages = retryMessages;
     }
-    if (successResponse) {
+    if (successResponse !== undefined) {
         if (logSuccess) {
             logSuccess(req, methodAndUrl, rawResponse, requestLogs, executeStartTime);
         }


### PR DESCRIPTION
Same fix as https://github.com/globality-corp/nodule-openapi/pull/95, but for auto-generated clients.