### PR TITLE
Adjust source of X-Request-Client

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.28.0
+current_version = 0.29.0
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-openapi",
-    "version": "0.28.0",
+    "version": "0.29.0",
     "description": "Opinionated OpenAPI (Swagger) Client",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-openapi.git",

--- a/src/clients/README.md
+++ b/src/clients/README.md
@@ -27,6 +27,7 @@ If a given function is not specified, the code defaults to the following set of 
 * X-Request-Id: Taken from `req.id`
 * X-Request-Started-At: Taken from `req._startTime` or the current datetime
 * X-Request-User: Taken from `req.locals.user.id`
+* X-Request-Client: Taken from `req.locals.client.id`
 * Jwt: A JSON stringifed representation of `req.locals.jwt`
 
 ## Logging

--- a/src/clients/__tests__/openapi.test.js
+++ b/src/clients/__tests__/openapi.test.js
@@ -262,8 +262,8 @@ describe('createOpenAPIClient', () => {
         const req2 = {
             id: 'request-id',
             locals: {
-                user: {
-                    clientId: 'client-id-123',
+                client: {
+                    id: 'client-id-123',
                 },
             },
         };

--- a/src/clients/openapi.js
+++ b/src/clients/openapi.js
@@ -53,7 +53,8 @@ function defaultExtendHeaders(req, headers) {
 
     // pass the client id from the user (if any)
     // this is so we can identify which client is making the request
-    const clientId = get(req, 'locals.client.id');
+    // prefer value from `locals.client`
+    const clientId = get(req, 'locals.client.id') || get(req, 'locals.user.clientId');
     if (clientId) {
         extendHeaders['X-Request-Client'] = clientId;
     }

--- a/src/clients/openapi.js
+++ b/src/clients/openapi.js
@@ -53,7 +53,7 @@ function defaultExtendHeaders(req, headers) {
 
     // pass the client id from the user (if any)
     // this is so we can identify which client is making the request
-    const clientId = get(req, 'locals.user.clientId');
+    const clientId = get(req, 'locals.client.id');
     if (clientId) {
         extendHeaders['X-Request-Client'] = clientId;
     }

--- a/src/openApiCodeGenClients/__test__/operation.test.js
+++ b/src/openApiCodeGenClients/__test__/operation.test.js
@@ -16,8 +16,8 @@ describe('createOpenAPIClient', () => {
     const req = {
         id: 'request-id',
         locals: {
-            user: {
-                clientId: 'client-id-123',
+            client: {
+                id: 'client-id-123',
             },
         },
     };


### PR DESCRIPTION
Why?
`X-Request-Client` shouldn't rely on local user, cause it may have different sources.

What?
Switched how the `X-Request-Client` is set.