### PR TITLE
Add request timeout in Styx

### DIFF
--- a/src/clients/__tests__/openapi.test.js
+++ b/src/clients/__tests__/openapi.test.js
@@ -312,4 +312,54 @@ describe('createOpenAPIClient', () => {
             'X-Request-Test': 'test',
         });
     });
+
+    it('timeout', async () => {
+        const config = await Nodule.testing().fromObject(
+            mockResponse('petstore', 'pet.search', {
+                items: [
+                    'abc',
+                ],
+            }),
+        ).load();
+
+        const reqTimeout = {
+            id: 'request-id',
+            locals: {
+                user: {},
+                startTime: process.hrtime(),
+                requestTotalMaxTimeInMillis: 100,
+            },
+        };
+
+        const client = createOpenAPIClient('petstore', spec);
+
+        const result = await client.pet.search(reqTimeout, { name: 'abc' }, {
+            additionalHeaders: {
+                'X-Request-Test': 'test',
+            },
+        });
+        expect(result).toEqual({
+            items: ['abc'],
+        });
+
+        expect(config.clients.mock.petstore.pet.search).toHaveBeenCalledTimes(1);
+        expect(config.clients.mock.petstore.pet.search.mock.calls[0][0].headers).toMatchObject({
+            Accept: 'application/json, text/plain, */*',
+            'Content-Type': 'application/json; charset=utf-8',
+            'X-Request-Service': 'test',
+            'X-Request-Test': 'test',
+        });
+
+        await new Promise(r => setTimeout(r, 101));
+
+        await expect(client.pet.search(reqTimeout, { name: 'abc' }, {
+            additionalHeaders: {
+                'X-Request-Test': 'test',
+            },
+        })).rejects.toThrow(
+            'Request took longer than allowed',
+        );
+
+        expect(config.clients.mock.petstore.pet.search).toHaveBeenCalledTimes(1);
+    });
 });

--- a/src/openApiCodeGenClients/__test__/operation.test.js
+++ b/src/openApiCodeGenClients/__test__/operation.test.js
@@ -11,7 +11,6 @@ class PetApi {
     }
 }
 
-
 describe('createOpenAPIClient', () => {
     const req = {
         id: 'request-id',
@@ -118,5 +117,48 @@ describe('createOpenAPIClient', () => {
         expect(spy).toHaveBeenCalledTimes(1);
         expect(spy.mock.calls[0][1].headers['X-Request-Client']).toBe(undefined);
         expect(spy.mock.calls[0][1].headers['X-Request-Test-Header']).toBe('test');
+    });
+
+
+    it('timeout', async () => {
+        await Nodule.testing().load();
+
+        const spy = jest.spyOn(PetApi.prototype, 'search');
+
+        const client = createOpenAPIClientV2('petstore', { petApi: PetApi }, spec);
+        const reqTimeout = {
+            id: 'request-id',
+            locals: {
+                user: {},
+                startTime: process.hrtime(),
+                requestTotalMaxTimeInMillis: 100,
+            },
+        };
+        const result = await client.petApi.search(reqTimeout, null, {
+            additionalHeaders: {
+                'X-Request-Test-Header': 'test',
+            },
+        });
+
+        expect(result).toEqual({
+            items: [
+                REX,
+            ],
+        });
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy.mock.calls[0][1].headers['X-Request-Client']).toBe(undefined);
+        expect(spy.mock.calls[0][1].headers['X-Request-Test-Header']).toBe('test');
+
+        await new Promise(r => setTimeout(r, 101));
+
+        await expect(client.petApi.search(reqTimeout, null, {
+            additionalHeaders: {
+                'X-Request-Test-Header': 'test',
+            },
+        })).rejects.toThrow(
+            'Request took longer than allowed',
+        );
+
+        expect(spy).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/openApiCodeGenClients/operation.js
+++ b/src/openApiCodeGenClients/operation.js
@@ -7,6 +7,7 @@ import buildError, { normalizeError } from '../error';
 import { isRetryableOperation } from '../operation';
 import buildResponse from '../response';
 import { createHeaders, createParamsWrapper } from './helpers';
+import { checkTimeout } from './utils';
 
 
 /* Create a new callable operation that return a Promise.
@@ -24,6 +25,7 @@ export default (
     requestMethod, // e.g get, post, put etc.
     path, // This is the path defined on the spec for the given operation
 ) => async (req, args, options) => {
+    checkTimeout(req);
     const operationName = `${resourceName}.${operation}`;
     const axiosRequestConfig = {
         adapter: buildAdapter({

--- a/src/openApiCodeGenClients/utils.js
+++ b/src/openApiCodeGenClients/utils.js
@@ -1,5 +1,9 @@
-import { camelCase, includes, isNil, lowerCase } from 'lodash';
+import { camelCase, has, includes, isNil, lowerCase } from 'lodash';
 
+// eslint-disable-next-line radix
+export const TIMEOUT_IN_MILLIS = parseInt(
+    process.env.REQUESTS__TOTAL_MAX_TIME_IN_MILLIS || `${60000}`,
+);
 
 export function isMutationOperation(requestMethod) {
     return includes(
@@ -13,6 +17,20 @@ export function isMutationOperation(requestMethod) {
     );
 }
 
+export function checkTimeout(req) {
+    // if not set, just exit, backwards compatibility
+    if (!has(req, 'locals') || !has(req.locals, 'startTime')) {
+        return;
+    }
+
+    const currentTime = process.hrtime(req.locals.startTime);
+    const elapsedTimeInMillis = (currentTime[0] * 1000) + (currentTime[1] / 1e6);
+    const timeout = req.locals.requestTotalMaxTimeInMillis || TIMEOUT_IN_MILLIS;
+
+    if (elapsedTimeInMillis > timeout) {
+        throw new Error('Request took longer than allowed');
+    }
+}
 
 export function convertResourceNameToBaseTags(ResourceApi) {
     // e.g ResourceApi = PublicV1Api

--- a/src/operation.js
+++ b/src/operation.js
@@ -8,6 +8,7 @@ import buildError, { normalizeError } from './error';
 import buildRequest from './request';
 import buildResponse from './response';
 import Validator from './validation';
+import { checkTimeout } from './openApiCodeGenClients/utils';
 
 
 function sleep(time) {
@@ -70,6 +71,8 @@ export function extendHeadersFromOptions(request, options) {
 /* Create a new callable operation that return a Promise.
  */
 export default (context, name, operationName) => async (req, args, options) => {
+    checkTimeout(req);
+
     // validate inputs
     Validator(context)(req, operationName, args);
 


### PR DESCRIPTION
* We want not to make any request during processing of multiple requests in the same initial request and throw error if we take longer than expected.
* This adds that possibility.
* We default to `60000` milliseconds = 1 minute
* We can set the global value with env var: `REQUESTS__TOTAL_MAX_TIME_IN_MILLIS`