### PR TITLE
Switch to bigint method for nano time

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.29.3
+current_version = 0.29.4
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-openapi",
-    "version": "0.29.3",
+    "version": "0.29.4",
     "description": "Opinionated OpenAPI (Swagger) Client",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-openapi.git",

--- a/src/clients/__tests__/openapi.test.js
+++ b/src/clients/__tests__/openapi.test.js
@@ -326,7 +326,7 @@ describe('createOpenAPIClient', () => {
             id: 'request-id',
             locals: {
                 user: {},
-                startTime: process.hrtime(),
+                startTime: process.hrtime.bigint(),
                 requestTotalMaxTimeInMillis: 100,
             },
         };

--- a/src/openApiCodeGenClients/__test__/operation.test.js
+++ b/src/openApiCodeGenClients/__test__/operation.test.js
@@ -130,7 +130,7 @@ describe('createOpenAPIClient', () => {
             id: 'request-id',
             locals: {
                 user: {},
-                startTime: process.hrtime(),
+                startTime: process.hrtime.bigint(),
                 requestTotalMaxTimeInMillis: 100,
             },
         };

--- a/src/openApiCodeGenClients/utils.js
+++ b/src/openApiCodeGenClients/utils.js
@@ -1,4 +1,5 @@
 import { camelCase, has, includes, isNil, lowerCase } from 'lodash';
+/* global BigInt */
 
 // eslint-disable-next-line radix
 export const TIMEOUT_IN_MILLIS = parseInt(
@@ -23,8 +24,8 @@ export function checkTimeout(req) {
         return;
     }
 
-    const currentTime = process.hrtime(req.locals.startTime);
-    const elapsedTimeInMillis = (currentTime[0] * 1000) + (currentTime[1] / 1e6);
+    const currentTime = process.hrtime.bigint();
+    const elapsedTimeInMillis = (currentTime - req.locals.startTime) / BigInt(1e6);
     const timeout = req.locals.requestTotalMaxTimeInMillis || TIMEOUT_IN_MILLIS;
 
     if (elapsedTimeInMillis > timeout) {


### PR DESCRIPTION
* Switch to bigint method. The other is deprecated.