### PR TITLE
reverting changes around warnings if no base url set

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-openapi",
-    "version": "0.32.0",
+    "version": "0.33.0",
     "description": "Opinionated OpenAPI (Swagger) Client",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-openapi.git",

--- a/src/clients/openapi.js
+++ b/src/clients/openapi.js
@@ -115,15 +115,6 @@ export function createOpenAPIClient(name, spec) {
     const config = getConfig(`clients.${name}`) || {};
     const { baseUrl, timeout, retries, namingOverride, namingPath, namingQuery } = config;
 
-    if (!baseUrl && (metadata.testing || metadata.debug)) {
-        // eslint-disable-next-line no-console
-        console.warn(
-            `Warning - no base url found for client '${name}'
-            - initializing a client in a non-development environment without
-            a base url present would lead to an exception being raised`,
-        );
-    }
-
     if (!baseUrl && !metadata.testing && !metadata.debug) {
         throw new Error(`OpenAPI client ${name} does not have a configured baseUrl`);
     }


### PR DESCRIPTION
Removing the warning around base clients not set. Added here -> https://github.com/globality-corp/nodule-openapi/pull/70/files

This causes so much spam in the test logs that it makes it completely useless as a warning.