### PR TITLE
Vitest support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-openapi",
-    "version": "0.34.0",
+    "version": "0.35.0",
     "description": "Opinionated OpenAPI (Swagger) Client",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-openapi.git",

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,8 @@ export {
 export {
     mockError,
     mockResponse,
+    mockResponseVitest,
+    mockErrorVitest,
 } from './testing';
 export { createOpenAPIClient } from './clients';
 export { createOpenAPIClientV2 } from './openApiCodeGenClients';

--- a/src/testing/index.js
+++ b/src/testing/index.js
@@ -1,1 +1,1 @@
-export { mockError, mockResponse } from './openapi';
+export { mockError, mockResponse, mockResponseVitest, mockErrorVitest } from './openapi';

--- a/src/testing/openapi.js
+++ b/src/testing/openapi.js
@@ -16,6 +16,18 @@ export function mockResponse(name, operationId, data, headers = { 'content-type'
     return obj;
 }
 
+export function mockResponseVitest(name, operationId, data, headers = { 'content-type': 'application/json' }) {
+    const obj = {};
+
+    // eslint-disable-next-line no-undef
+    set(obj, `clients.mock.${name}.${operationId}`, vitest.fn(async req => ({
+        data: isFunction(data) ? data(req.params || JSON.parse(req.data || null), req.url) : data,
+        headers,
+    })));
+
+    return obj;
+}
+
 
 /* Mock a client (OpenAPI) error.
  */
@@ -23,6 +35,17 @@ export function mockError(name, operationId, message, code, data = null) {
     const obj = {};
 
     set(obj, `clients.mock.${name}.${operationId}`, jest.fn(async () => {
+        throw new OpenAPIError(message, code, data);
+    }));
+
+    return obj;
+}
+
+export function mockErrorVitest(name, operationId, message, code, data = null) {
+    const obj = {};
+
+    // eslint-disable-next-line no-undef
+    set(obj, `clients.mock.${name}.${operationId}`, vitest.fn(async () => {
         throw new OpenAPIError(message, code, data);
     }));
 


### PR DESCRIPTION
I'm looking into migrating capote to vitest since it has native support for TypeScript and ES6 modules.
The only problem is that we use `mockResponse` a lot and this repo uses jest under the hood, so we need another `mockResponse` and `mockError` that uses vitest instead.
